### PR TITLE
Set hardwareAcceleration to  'prefer-software' by default

### DIFF
--- a/src/media/decoders/decoder-video.js
+++ b/src/media/decoders/decoder-video.js
@@ -100,7 +100,7 @@ self.addEventListener("message", async function (e) {
         codec: config.codec,
         codedWidth: config.width,
         codedHeight: config.height,
-        hardwareAcceleration: 'prefer-software'
+        hardwareAcceleration: "prefer-software",
         // optimizeForLatency: true,
       };
       if (config.hardwareAcceleration) {


### PR DESCRIPTION
Set hardwareAcceleration to  'prefer-software' by default. In other case hardware acceleration is still enabled.