### PR TITLE
Fix player flickering in VOD mode when height is set to auto

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,9 @@ jobs:
 
       - name: Run Tests
         run: npm run test:ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Browser Tests
+        run: npm run test:browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.8.0",
       "license": "MIT",
       "devDependencies": {
+        "@vitest/browser-playwright": "^4.1.5",
         "@vitest/coverage-v8": "^4.0.18",
         "jsdom": "^28.1.0",
         "prettier": "^3.8.3",
@@ -135,6 +136,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@blazediff/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -815,6 +823,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -1272,6 +1287,53 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@vitest/browser": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.5.tgz",
+      "integrity": "sha512-iCDGI8c4yg+xmjUg2VsygdAUSIIB4x5Rht/P68OXy1hPELKXHDkzh87lkuTcdYmemRChDkEpB426MmDjzC0ziA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@blazediff/core": "1.9.1",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.1.0",
+        "ws": "^8.19.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.5"
+      }
+    },
+    "node_modules/@vitest/browser-playwright": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.5.tgz",
+      "integrity": "sha512-CWy0lBQJq97nionyJJdnaU4961IXTl43a7UCu5nHy51IoKxAt6PVIJLo+76rVl7KOOgcWHNkG4kbJu/pW7knvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/browser": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": false
+        }
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -2161,6 +2223,16 @@
         "node": "*"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2266,6 +2338,66 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {
@@ -2484,6 +2616,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2644,6 +2791,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {
@@ -2986,6 +3143,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -66,10 +66,12 @@
     "prettier:write": "prettier --write .",
     "test": "vitest",
     "test:ci": "vitest run",
+    "test:browser": "vitest run --config vitest.browser.config.js",
     "coverage": "npx vitest run --coverage tests",
     "prepublishOnly": "npm run test:ci && npm run build:pkg"
   },
   "devDependencies": {
+    "@vitest/browser-playwright": "^4.1.5",
     "@vitest/coverage-v8": "^4.0.18",
     "jsdom": "^28.1.0",
     "prettier": "^3.8.3",

--- a/src/ui/height-probe.js
+++ b/src/ui/height-probe.js
@@ -1,41 +1,31 @@
-// A percentage height resolves only against a definite containing
-// block, and definiteness is recursive (the parent may itself be a
-// percentage of an auto-height ancestor) - so ask the layout engine
-// with an in-flow probe: offsetHeight stays 0 exactly when the
-// percentage fails to resolve. Every box property is pinned with
-// inline !important declarations, which outrank any host stylesheet
-// rule (including stylesheet !important), so page CSS matching the
-// probe div (padding, borders, min-height, ...) cannot fake a definite
-// verdict. flex:0 0 auto keeps a column flex parent from shrinking the
-// probe. A definite height of exactly 0 still reads as indefinite -
-// unavoidable with any measurement, and it routes a zero-sized
-// (invisible) player to the stable branch. The synchronous
-// append/measure/remove never reaches a rendering step, so a
-// ResizeObserver does not see it.
-const PROBE_STYLES = {
-  position: "static",
-  display: "block",
-  "box-sizing": "border-box",
-  height: "100%",
-  width: "0",
-  "min-height": "0",
-  "max-height": "none",
-  margin: "0",
-  padding: "0",
-  border: "none",
-  flex: "0 0 auto",
-  "align-self": "auto",
-  transform: "none",
-  visibility: "hidden",
-};
-
-export function probeParentHeightDefinite(parent) {
-  const probe = document.createElement("div");
-  for (const [prop, value] of Object.entries(PROBE_STYLES)) {
-    probe.style.setProperty(prop, value, "important");
-  }
-  parent.appendChild(probe);
-  const definite = probe.offsetHeight > 0;
-  probe.remove();
-  return definite;
+// Answers the question the flicker guard actually depends on: does the
+// output element's size feed back into the container's height? The
+// rect-based fit oscillates exactly when it does (#86).
+//
+// Instead of inserting a synthetic element next to the container -
+// which measures a proxy (the parent's definiteness) and is open to
+// contamination through pseudo-element rules on empty children and
+// structural selectors (:empty, :has, :nth-child) reacting to the
+// temporary child - this flips the EXISTING output element's inline
+// height between two extremes and checks whether the container's
+// height follows. Nothing is inserted, so the DOM structure the host's
+// selectors see never changes, and the verdict reflects the
+// container's real computed height semantics: an unresolvable
+// percentage, an auto-valued var(), or an inherited auto all read as
+// content-sized no matter what the parent looks like.
+//
+// transition:none is pinned during the measurement so a host
+// transition on the output cannot freeze the used height between the
+// two reads. Inline styles are restored verbatim afterwards, and the
+// synchronous flip never reaches a rendering step, so a ResizeObserver
+// does not see it.
+export function containerHeightIndependent(container, output) {
+  const savedCss = output.style.cssText;
+  output.style.setProperty("transition", "none", "important");
+  output.style.setProperty("height", "1px", "important");
+  const low = container.offsetHeight;
+  output.style.setProperty("height", "99999px", "important");
+  const high = container.offsetHeight;
+  output.style.cssText = savedCss;
+  return low === high;
 }

--- a/src/ui/height-probe.js
+++ b/src/ui/height-probe.js
@@ -1,0 +1,41 @@
+// A percentage height resolves only against a definite containing
+// block, and definiteness is recursive (the parent may itself be a
+// percentage of an auto-height ancestor) - so ask the layout engine
+// with an in-flow probe: offsetHeight stays 0 exactly when the
+// percentage fails to resolve. Every box property is pinned with
+// inline !important declarations, which outrank any host stylesheet
+// rule (including stylesheet !important), so page CSS matching the
+// probe div (padding, borders, min-height, ...) cannot fake a definite
+// verdict. flex:0 0 auto keeps a column flex parent from shrinking the
+// probe. A definite height of exactly 0 still reads as indefinite -
+// unavoidable with any measurement, and it routes a zero-sized
+// (invisible) player to the stable branch. The synchronous
+// append/measure/remove never reaches a rendering step, so a
+// ResizeObserver does not see it.
+const PROBE_STYLES = {
+  position: "static",
+  display: "block",
+  "box-sizing": "border-box",
+  height: "100%",
+  width: "0",
+  "min-height": "0",
+  "max-height": "none",
+  margin: "0",
+  padding: "0",
+  border: "none",
+  flex: "0 0 auto",
+  "align-self": "auto",
+  transform: "none",
+  visibility: "hidden",
+};
+
+export function probeParentHeightDefinite(parent) {
+  const probe = document.createElement("div");
+  for (const [prop, value] of Object.entries(PROBE_STYLES)) {
+    probe.style.setProperty(prop, value, "important");
+  }
+  parent.appendChild(probe);
+  const definite = probe.offsetHeight > 0;
+  probe.remove();
+  return definite;
+}

--- a/src/ui/height-probe.js
+++ b/src/ui/height-probe.js
@@ -14,18 +14,46 @@
 // percentage, an auto-valued var(), or an inherited auto all read as
 // content-sized no matter what the parent looks like.
 //
-// transition:none is pinned during the measurement so a host
-// transition on the output cannot freeze the used height between the
-// two reads. Inline styles are restored verbatim afterwards, and the
-// synchronous flip never reaches a rendering step, so a ResizeObserver
-// does not see it.
+// Side-effect containment:
+// - transition:none stays pinned until one style change event has seen
+//   the restored height, so re-enabling a host transition cannot
+//   animate from the probe value (the before/after-change rule of the
+//   CSS transitions model). A host transition already running on the
+//   output when the probe fires is necessarily cancelled and snaps to
+//   its end value - unavoidable with any synchronous measurement.
+// - Ancestor scroll offsets are snapshotted first and re-applied last:
+//   the 1px pass shrinks ancestor scroll ranges, and an engine may
+//   clamp scrollTop during the forced layout and keep the clamped
+//   value (Chromium restores it within the same task, but that is not
+//   guaranteed elsewhere).
+// - The synchronous flip never reaches a rendering step, so a
+//   ResizeObserver does not see it, and inline styles are restored
+//   verbatim.
 export function containerHeightIndependent(container, output) {
   const savedCss = output.style.cssText;
+  const savedScrolls = [];
+  for (let el = container; el; el = el.parentElement) {
+    if (el.scrollTop || el.scrollLeft) {
+      savedScrolls.push([el, el.scrollTop, el.scrollLeft]);
+    }
+  }
+
   output.style.setProperty("transition", "none", "important");
   output.style.setProperty("height", "1px", "important");
   const low = container.offsetHeight;
   output.style.setProperty("height", "99999px", "important");
   const high = container.offsetHeight;
+
   output.style.cssText = savedCss;
+  output.style.setProperty("transition", "none", "important");
+  // Style change event with the steady height while transitions are
+  // still off; the next event then sees no height difference.
+  void output.offsetHeight;
+  output.style.cssText = savedCss;
+
+  for (const [el, top, left] of savedScrolls) {
+    el.scrollTop = top;
+    el.scrollLeft = left;
+  }
   return low === high;
 }

--- a/src/ui/height-probe.js
+++ b/src/ui/height-probe.js
@@ -45,9 +45,12 @@ export function containerHeightIndependent(container, output) {
 
   const savedCss = output.style.cssText;
   const savedScrolls = [];
+  // nodeType instead of instanceof: an ancestor adopted into a
+  // same-origin iframe's document belongs to another realm, where the
+  // local Element global would not match.
   for (
     let node = container;
-    node instanceof Element;
+    node && node.nodeType === 1;
     node =
       node.assignedSlot ?? node.parentElement ?? node.getRootNode().host ?? null
   ) {

--- a/src/ui/height-probe.js
+++ b/src/ui/height-probe.js
@@ -78,8 +78,14 @@ export function containerHeightIndependent(container, output) {
     }
     output.style.cssText = savedCss;
     for (const [node, top, left] of savedScrolls) {
-      node.scrollTop = top;
-      node.scrollLeft = left;
+      // behavior:"instant" so a host `scroll-behavior: smooth` cannot
+      // animate the restoration on engines that keep the clamped offset
+      if (typeof node.scrollTo === "function") {
+        node.scrollTo({ top, left, behavior: "instant" });
+      } else {
+        node.scrollTop = top;
+        node.scrollLeft = left;
+      }
     }
   }
   return low === high;

--- a/src/ui/height-probe.js
+++ b/src/ui/height-probe.js
@@ -15,45 +15,71 @@
 // content-sized no matter what the parent looks like.
 //
 // Side-effect containment:
+// - Measuring requires transition:none on the output, which would
+//   cancel every CSS transition currently running there and snap it to
+//   its end value. If one is running, the probe returns null instead
+//   of measuring - the caller keeps its previous verdict, the
+//   animation survives, and the resize events it produces re-run the
+//   probe once it has finished.
 // - transition:none stays pinned until one style change event has seen
 //   the restored height, so re-enabling a host transition cannot
 //   animate from the probe value (the before/after-change rule of the
-//   CSS transitions model). A host transition already running on the
-//   output when the probe fires is necessarily cancelled and snaps to
-//   its end value - unavoidable with any synchronous measurement.
-// - Ancestor scroll offsets are snapshotted first and re-applied last:
-//   the 1px pass shrinks ancestor scroll ranges, and an engine may
-//   clamp scrollTop during the forced layout and keep the clamped
-//   value (Chromium restores it within the same task, but that is not
+//   CSS transitions model).
+// - Ancestor scroll offsets - walking the composed tree through shadow
+//   root hosts - are snapshotted first and re-applied last: the 1px
+//   pass shrinks ancestor scroll ranges, and an engine may clamp
+//   scrollTop during the forced layout and keep the clamped value
+//   (Chromium restores it within the same task, but that is not
 //   guaranteed elsewhere).
+// - Restoration runs in a finally block, so styles and scroll come
+//   back even if a measurement throws.
 // - The synchronous flip never reaches a rendering step, so a
 //   ResizeObserver does not see it, and inline styles are restored
 //   verbatim.
 export function containerHeightIndependent(container, output) {
+  if (
+    typeof output.getAnimations === "function" &&
+    output
+      .getAnimations()
+      .some((a) => "transitionProperty" in a && a.playState === "running")
+  ) {
+    return null;
+  }
+
   const savedCss = output.style.cssText;
   const savedScrolls = [];
-  for (let el = container; el; el = el.parentElement) {
-    if (el.scrollTop || el.scrollLeft) {
-      savedScrolls.push([el, el.scrollTop, el.scrollLeft]);
+  for (
+    let node = container;
+    node instanceof Element;
+    node = node.parentElement ?? node.getRootNode().host ?? null
+  ) {
+    if (node.scrollTop || node.scrollLeft) {
+      savedScrolls.push([node, node.scrollTop, node.scrollLeft]);
     }
   }
 
-  output.style.setProperty("transition", "none", "important");
-  output.style.setProperty("height", "1px", "important");
-  const low = container.offsetHeight;
-  output.style.setProperty("height", "99999px", "important");
-  const high = container.offsetHeight;
-
-  output.style.cssText = savedCss;
-  output.style.setProperty("transition", "none", "important");
-  // Style change event with the steady height while transitions are
-  // still off; the next event then sees no height difference.
-  void output.offsetHeight;
-  output.style.cssText = savedCss;
-
-  for (const [el, top, left] of savedScrolls) {
-    el.scrollTop = top;
-    el.scrollLeft = left;
+  let low, high;
+  try {
+    output.style.setProperty("transition", "none", "important");
+    output.style.setProperty("height", "1px", "important");
+    low = container.offsetHeight;
+    output.style.setProperty("height", "99999px", "important");
+    high = container.offsetHeight;
+  } finally {
+    output.style.cssText = savedCss;
+    output.style.setProperty("transition", "none", "important");
+    try {
+      // Style change event with the steady height while transitions
+      // are still off; the next event then sees no height difference.
+      void output.offsetHeight;
+    } catch {
+      // measurement is best-effort during cleanup
+    }
+    output.style.cssText = savedCss;
+    for (const [node, top, left] of savedScrolls) {
+      node.scrollTop = top;
+      node.scrollLeft = left;
+    }
   }
   return low === high;
 }

--- a/src/ui/height-probe.js
+++ b/src/ui/height-probe.js
@@ -16,33 +16,30 @@
 //
 // Side-effect containment:
 // - Measuring requires transition:none on the output, which would
-//   cancel every CSS transition currently running there and snap it to
-//   its end value. If one is running, the probe returns null instead
-//   of measuring - the caller keeps its previous verdict, the
-//   animation survives, and the resize events it produces re-run the
-//   probe once it has finished.
+//   cancel every CSS transition currently live there - running OR
+//   paused - and snap it to its end value. If any exists, the probe
+//   returns null instead of measuring; the caller keeps its previous
+//   verdict and uses whenOutputTransitionsSettled() to re-measure once
+//   they finish (a transition that stays paused forever keeps the
+//   stale verdict - the only alternative would be destroying it).
 // - transition:none stays pinned until one style change event has seen
 //   the restored height, so re-enabling a host transition cannot
 //   animate from the probe value (the before/after-change rule of the
 //   CSS transitions model).
-// - Ancestor scroll offsets - walking the composed tree through shadow
-//   root hosts - are snapshotted first and re-applied last: the 1px
-//   pass shrinks ancestor scroll ranges, and an engine may clamp
-//   scrollTop during the forced layout and keep the clamped value
-//   (Chromium restores it within the same task, but that is not
-//   guaranteed elsewhere).
+// - Ancestor scroll offsets - walking the FLAT tree: slotted content
+//   steps into its assigned slot's shadow-tree ancestry, and shadow
+//   roots step out through their host - are snapshotted first and
+//   re-applied last: the 1px pass shrinks ancestor scroll ranges, and
+//   an engine may clamp scrollTop during the forced layout and keep
+//   the clamped value (Chromium restores it within the same task, but
+//   that is not guaranteed elsewhere).
 // - Restoration runs in a finally block, so styles and scroll come
 //   back even if a measurement throws.
 // - The synchronous flip never reaches a rendering step, so a
 //   ResizeObserver does not see it, and inline styles are restored
 //   verbatim.
 export function containerHeightIndependent(container, output) {
-  if (
-    typeof output.getAnimations === "function" &&
-    output
-      .getAnimations()
-      .some((a) => "transitionProperty" in a && a.playState === "running")
-  ) {
+  if (outputTransitions(output).length) {
     return null;
   }
 
@@ -51,7 +48,8 @@ export function containerHeightIndependent(container, output) {
   for (
     let node = container;
     node instanceof Element;
-    node = node.parentElement ?? node.getRootNode().host ?? null
+    node =
+      node.assignedSlot ?? node.parentElement ?? node.getRootNode().host ?? null
   ) {
     if (node.scrollTop || node.scrollLeft) {
       savedScrolls.push([node, node.scrollTop, node.scrollLeft]);
@@ -82,4 +80,23 @@ export function containerHeightIndependent(container, output) {
     }
   }
   return low === high;
+}
+
+function outputTransitions(output) {
+  if (typeof output.getAnimations !== "function") return [];
+  return output.getAnimations().filter((a) => "transitionProperty" in a);
+}
+
+// Retry hook for a deferred probe: invokes callback once every CSS
+// transition currently live on the output has finished or been
+// cancelled, and returns true. Returns false without scheduling when
+// there is nothing to wait for (the caller can probe again right
+// away). Without this, a transition that never resizes the container -
+// an opacity fade, say - would produce no ResizeObserver events and a
+// deferred verdict would stay stale forever.
+export function whenOutputTransitionsSettled(output, callback) {
+  const transitions = outputTransitions(output);
+  if (!transitions.length) return false;
+  Promise.allSettled(transitions.map((t) => t.finished)).then(callback);
+  return true;
 }

--- a/src/ui/layout-manager.js
+++ b/src/ui/layout-manager.js
@@ -186,7 +186,8 @@ export class UILayoutManager {
       return "intrinsic";
     }
     if (
-      /^\+?(\d+(\.\d+)?|\.\d+)(e[+-]?\d+)?(px|em|rem|ex|ch|cap|ic|lh|rlh|vw|vh|vmin|vmax|vi|vb|svw|svh|lvw|lvh|dvw|dvh|cqw|cqh|cqi|cqb|cqmin|cqmax|cm|mm|q|in|pt|pc)$/.test(
+      v === "0" ||
+      /^\+?(\d+(\.\d+)?|\.\d+)(e[+-]?\d+)?(px|em|rem|ex|ch|cap|ic|lh|rlh|rex|rch|rcap|ric|vw|vh|vmin|vmax|vi|vb|svw|svh|svi|svb|svmin|svmax|lvw|lvh|lvi|lvb|lvmin|lvmax|dvw|dvh|dvi|dvb|dvmin|dvmax|cqw|cqh|cqi|cqb|cqmin|cqmax|cm|mm|q|in|pt|pc)$/.test(
         v,
       )
     ) {

--- a/src/ui/layout-manager.js
+++ b/src/ui/layout-manager.js
@@ -59,7 +59,7 @@ export class UILayoutManager {
     };
   }
 
-  heightNeedsParentProbe() {
+  heightNeedsProbe() {
     return this._cssSizeKind(this._cssHeight) === "relative";
   }
 
@@ -69,7 +69,7 @@ export class UILayoutManager {
     mode,
     isFullscreen,
     isMediaElementMode,
-    parentHeightDefinite = false,
+    heightIndependent = false,
   ) {
     if (!this._ar || this._paused) return null;
 
@@ -89,7 +89,7 @@ export class UILayoutManager {
     } else if (mode === MODE.VOD || isMediaElementMode) {
       const widthAuto = this._cssSizeKind(this._cssWidth) === "intrinsic";
       const heightIndefinite =
-        !isFullscreen && this._isHeightIndefinite(parentHeightDefinite);
+        !isFullscreen && this._isHeightIndefinite(heightIndependent);
       if (heightIndefinite) {
         // With an indefinite HEIGHT (auto, a content-based keyword, or a
         // percentage against a parent with no definite height) the
@@ -168,13 +168,11 @@ export class UILayoutManager {
   // "intrinsic" - computes to a content-based height, always indefinite
   // (auto, fit-content and friends, and the css-wide keywords that fall
   // back to auto for height);
-  // "relative" - definite only when the parent height is definite, which
-  // the caller resolves with a DOM probe: percentages by CSS rule;
-  // inherit because it copies the parent's computed height, whose
-  // definiteness is exactly what the probe measures; var() because it
-  // can hide any value and the probe branch is stable either way (at
-  // worst a definite var() in an auto-height parent loses the letterbox
-  // fit, while guessing "definite" could reintroduce the oscillation);
+  // "relative" - context-dependent, so the caller resolves it with a
+  // DOM probe that measures whether the container's height actually
+  // follows the output (percentages depend on the ancestor chain,
+  // inherit copies the parent's computed height, and var() can hide
+  // any value including auto);
   // "definite" - an absolute length, always trustworthy for the rect fit.
   _cssSizeKind(value) {
     if (!value) return "intrinsic";
@@ -192,10 +190,10 @@ export class UILayoutManager {
     return "definite";
   }
 
-  _isHeightIndefinite(parentHeightDefinite) {
+  _isHeightIndefinite(heightIndependent) {
     const kind = this._cssSizeKind(this._cssHeight);
     if (kind === "intrinsic") return true;
-    if (kind === "relative") return !parentHeightDefinite;
+    if (kind === "relative") return !heightIndependent;
     return false;
   }
 

--- a/src/ui/layout-manager.js
+++ b/src/ui/layout-manager.js
@@ -186,7 +186,7 @@ export class UILayoutManager {
       return "intrinsic";
     }
     if (
-      /^(\d+(\.\d+)?|\.\d+)(px|em|rem|ex|ch|cap|ic|lh|rlh|vw|vh|vmin|vmax|vi|vb|svw|svh|lvw|lvh|dvw|dvh|cqw|cqh|cqi|cqb|cqmin|cqmax|cm|mm|q|in|pt|pc)$/.test(
+      /^\+?(\d+(\.\d+)?|\.\d+)(e[+-]?\d+)?(px|em|rem|ex|ch|cap|ic|lh|rlh|vw|vh|vmin|vmax|vi|vb|svw|svh|lvw|lvh|dvw|dvh|cqw|cqh|cqi|cqb|cqmin|cqmax|cm|mm|q|in|pt|pc)$/.test(
         v,
       )
     ) {

--- a/src/ui/layout-manager.js
+++ b/src/ui/layout-manager.js
@@ -59,7 +59,18 @@ export class UILayoutManager {
     };
   }
 
-  fullLayout(cWidth, cHeight, mode, isFullscreen, isMediaElementMode) {
+  heightNeedsParentProbe() {
+    return this._cssSizeKind(this._cssHeight) === "relative";
+  }
+
+  fullLayout(
+    cWidth,
+    cHeight,
+    mode,
+    isFullscreen,
+    isMediaElementMode,
+    parentHeightDefinite = false,
+  ) {
     if (!this._ar || this._paused) return null;
 
     let res = { container: this.containerLayout(isFullscreen) };
@@ -77,13 +88,16 @@ export class UILayoutManager {
       }
     } else if (mode === MODE.VOD || isMediaElementMode) {
       const widthAuto = res.container.width === "auto";
-      const heightAuto = res.container.height === "auto";
-      if (heightAuto) {
-        // With an auto HEIGHT the container is sized by the output itself,
-        // so a rect-based fit feeds back and oscillates - width constrains,
-        // aspect-ratio keeps the shape. An auto WIDTH is parent-derived on
-        // a block container, so the rect fit below stays valid for it
-        // (assumes the container remains display:block).
+      const heightIndefinite =
+        !isFullscreen && this._isHeightIndefinite(parentHeightDefinite);
+      if (heightIndefinite) {
+        // With an indefinite HEIGHT (auto, a content-based keyword, or a
+        // percentage against a parent with no definite height) the
+        // container is sized by the output itself, so a rect-based fit
+        // feeds back and oscillates - width constrains, aspect-ratio
+        // keeps the shape. An auto WIDTH is parent-derived on a block
+        // container, so the rect fit below stays valid for it (assumes
+        // the container remains display:block).
         res.output.width = widthAuto ? "auto" : "100%";
         res.output.height = "auto";
       } else {
@@ -149,6 +163,25 @@ export class UILayoutManager {
     if (isNaN(x) || isNaN(y)) return;
 
     this._ar = { x, y, str: `${x} / ${y}`, val: x / y };
+  }
+
+  // "intrinsic" - content-based, always indefinite (auto, fit-content, ...);
+  // "relative" - contains a percentage, definite only when the parent
+  // height is definite (the caller resolves that with a DOM probe);
+  // "definite" - an absolute length, always trustworthy for the rect fit.
+  _cssSizeKind(value) {
+    if (!value || /^(auto|fit-content|min-content|max-content)\b/.test(value)) {
+      return "intrinsic";
+    }
+    if (value.includes("%")) return "relative";
+    return "definite";
+  }
+
+  _isHeightIndefinite(parentHeightDefinite) {
+    const kind = this._cssSizeKind(this._cssHeight);
+    if (kind === "intrinsic") return true;
+    if (kind === "relative") return !parentHeightDefinite;
+    return false;
   }
 
   _toCssSize(value) {

--- a/src/ui/layout-manager.js
+++ b/src/ui/layout-manager.js
@@ -76,15 +76,27 @@ export class UILayoutManager {
         res.output.height = "100%";
       }
     } else if (mode === MODE.VOD || isMediaElementMode) {
-      let cAspect = cWidth / cHeight;
-      let wDiff = (cAspect - this._ar.val) * cHeight;
-      if (wDiff > -1) {
-        // width difference doesn't exceed 1 pixel
-        res.output.height = "100%";
-        res.output.width = isMediaElementMode ? `${cWidth}px` : "auto";
+      const widthAuto = res.container.width === "auto";
+      const heightAuto = res.container.height === "auto";
+      if (heightAuto) {
+        // With an auto HEIGHT the container is sized by the output itself,
+        // so a rect-based fit feeds back and oscillates - width constrains,
+        // aspect-ratio keeps the shape. An auto WIDTH is parent-derived on
+        // a block container, so the rect fit below stays valid for it
+        // (assumes the container remains display:block).
+        res.output.width = widthAuto ? "auto" : "100%";
+        res.output.height = "auto";
       } else {
-        res.output.width = "100%";
-        res.output.height = isMediaElementMode ? `${cHeight}px` : "auto";
+        let cAspect = cWidth / cHeight;
+        let wDiff = (cAspect - this._ar.val) * cHeight;
+        if (wDiff > -1) {
+          // width difference doesn't exceed 1 pixel
+          res.output.height = "100%";
+          res.output.width = isMediaElementMode ? `${cWidth}px` : "auto";
+        } else {
+          res.output.width = "100%";
+          res.output.height = isMediaElementMode ? `${cHeight}px` : "auto";
+        }
       }
     }
 

--- a/src/ui/layout-manager.js
+++ b/src/ui/layout-manager.js
@@ -168,12 +168,13 @@ export class UILayoutManager {
   // "intrinsic" - computes to a content-based height, always indefinite
   // (auto, fit-content and friends, and the css-wide keywords that fall
   // back to auto for height);
-  // "relative" - context-dependent, so the caller resolves it with a
-  // DOM probe that measures whether the container's height actually
-  // follows the output (percentages depend on the ancestor chain,
-  // inherit copies the parent's computed height, and var() can hide
-  // any value including auto);
-  // "definite" - an absolute length, always trustworthy for the rect fit.
+  // "definite" - a positively recognized plain absolute length, the
+  // only syntax trusted without measurement;
+  // "relative" - everything else is context-dependent or unknown
+  // (%, var(), env() with a possibly-auto fallback, calc(),
+  // calc-size(), inherit, future grammar) and is resolved by the DOM
+  // probe in ui.js, which measures whether the container's height
+  // actually follows the output.
   _cssSizeKind(value) {
     if (!value) return "intrinsic";
     const v = String(value).trim().toLowerCase();
@@ -184,10 +185,14 @@ export class UILayoutManager {
     ) {
       return "intrinsic";
     }
-    if (v.includes("%") || v.includes("var(") || v === "inherit") {
-      return "relative";
+    if (
+      /^[\d.]+(px|em|rem|ex|ch|cap|ic|lh|rlh|vw|vh|vmin|vmax|vi|vb|svw|svh|lvw|lvh|dvw|dvh|cqw|cqh|cqi|cqb|cqmin|cqmax|cm|mm|q|in|pt|pc)$/.test(
+        v,
+      )
+    ) {
+      return "definite";
     }
-    return "definite";
+    return "relative";
   }
 
   _isHeightIndefinite(heightIndependent) {

--- a/src/ui/layout-manager.js
+++ b/src/ui/layout-manager.js
@@ -59,6 +59,10 @@ export class UILayoutManager {
     };
   }
 
+  canLayout() {
+    return !!this._ar && !this._paused;
+  }
+
   heightNeedsProbe() {
     return this._cssSizeKind(this._cssHeight) === "relative";
   }

--- a/src/ui/layout-manager.js
+++ b/src/ui/layout-manager.js
@@ -87,7 +87,7 @@ export class UILayoutManager {
         res.output.height = "100%";
       }
     } else if (mode === MODE.VOD || isMediaElementMode) {
-      const widthAuto = res.container.width === "auto";
+      const widthAuto = this._cssSizeKind(this._cssWidth) === "intrinsic";
       const heightIndefinite =
         !isFullscreen && this._isHeightIndefinite(parentHeightDefinite);
       if (heightIndefinite) {
@@ -165,15 +165,30 @@ export class UILayoutManager {
     this._ar = { x, y, str: `${x} / ${y}`, val: x / y };
   }
 
-  // "intrinsic" - content-based, always indefinite (auto, fit-content, ...);
-  // "relative" - contains a percentage, definite only when the parent
-  // height is definite (the caller resolves that with a DOM probe);
+  // "intrinsic" - computes to a content-based height, always indefinite
+  // (auto, fit-content and friends, and the css-wide keywords that fall
+  // back to auto for height);
+  // "relative" - definite only when the parent height is definite, which
+  // the caller resolves with a DOM probe: percentages by CSS rule;
+  // inherit because it copies the parent's computed height, whose
+  // definiteness is exactly what the probe measures; var() because it
+  // can hide any value and the probe branch is stable either way (at
+  // worst a definite var() in an auto-height parent loses the letterbox
+  // fit, while guessing "definite" could reintroduce the oscillation);
   // "definite" - an absolute length, always trustworthy for the rect fit.
   _cssSizeKind(value) {
-    if (!value || /^(auto|fit-content|min-content|max-content)\b/.test(value)) {
+    if (!value) return "intrinsic";
+    const v = String(value).trim().toLowerCase();
+    if (
+      /^(auto|fit-content|min-content|max-content|initial|unset|revert)\b/.test(
+        v,
+      )
+    ) {
       return "intrinsic";
     }
-    if (value.includes("%")) return "relative";
+    if (v.includes("%") || v.includes("var(") || v === "inherit") {
+      return "relative";
+    }
     return "definite";
   }
 

--- a/src/ui/layout-manager.js
+++ b/src/ui/layout-manager.js
@@ -186,7 +186,7 @@ export class UILayoutManager {
       return "intrinsic";
     }
     if (
-      /^[\d.]+(px|em|rem|ex|ch|cap|ic|lh|rlh|vw|vh|vmin|vmax|vi|vb|svw|svh|lvw|lvh|dvw|dvh|cqw|cqh|cqi|cqb|cqmin|cqmax|cm|mm|q|in|pt|pc)$/.test(
+      /^(\d+(\.\d+)?|\.\d+)(px|em|rem|ex|ch|cap|ic|lh|rlh|vw|vh|vmin|vmax|vi|vb|svw|svh|lvw|lvh|dvw|dvh|cqw|cqh|cqi|cqb|cqmin|cqmax|cm|mm|q|in|pt|pc)$/.test(
         v,
       )
     ) {

--- a/src/ui/layout-manager.js
+++ b/src/ui/layout-manager.js
@@ -167,22 +167,20 @@ export class UILayoutManager {
 
   // "intrinsic" - computes to a content-based height, always indefinite
   // (auto, fit-content and friends, and the css-wide keywords that fall
-  // back to auto for height);
+  // back to auto for height - NOT revert/revert-layer, which roll back
+  // to user-origin or lower-layer author styles that may define a
+  // definite height);
   // "definite" - a positively recognized plain absolute length, the
   // only syntax trusted without measurement;
   // "relative" - everything else is context-dependent or unknown
   // (%, var(), env() with a possibly-auto fallback, calc(),
-  // calc-size(), inherit, future grammar) and is resolved by the DOM
-  // probe in ui.js, which measures whether the container's height
-  // actually follows the output.
+  // calc-size(), inherit, revert, revert-layer, future grammar) and is
+  // resolved by the DOM probe in ui.js, which measures whether the
+  // container's height actually follows the output.
   _cssSizeKind(value) {
     if (!value) return "intrinsic";
     const v = String(value).trim().toLowerCase();
-    if (
-      /^(auto|fit-content|min-content|max-content|initial|unset|revert)\b/.test(
-        v,
-      )
-    ) {
+    if (/^(auto|fit-content|min-content|max-content|initial|unset)\b/.test(v)) {
       return "intrinsic";
     }
     if (

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -640,6 +640,7 @@ export class UI {
       !isFullscreen &&
       !canvasOutput &&
       output &&
+      this._layoutMgr.canLayout() &&
       this._layoutMgr.heightNeedsProbe()
     ) {
       const probed = containerHeightIndependent(this._container, output);

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -10,7 +10,7 @@ import { UIThumbnailPreview } from "./thumbnail-preview";
 import { UICaptionController } from "./caption-controller";
 import { UICaptionList } from "./caption-list";
 import { UILayoutManager } from "./layout-manager";
-import { probeParentHeightDefinite } from "./height-probe";
+import { containerHeightIndependent } from "./height-probe";
 import { UiPip } from "./ui-pip";
 import { MODE } from "@/shared/values";
 import OffscreenRendererWorker from "./offscreen-renderer-worker.js?worker";
@@ -627,9 +627,19 @@ export class UI {
 
   _resizeAndRedraw(rect, pipMode) {
     const isFullscreen = pipMode || this._isPlayerFullscreen();
-    let parentHeightDefinite = false;
-    if (!isFullscreen && this._layoutMgr.heightNeedsParentProbe()) {
-      parentHeightDefinite = this._isParentHeightDefinite();
+    const canvasOutput = this._mode === MODE.LIVE && !this._mediaElementMode;
+    const output = canvasOutput ? this._canvas : this._mediaElement;
+    let heightIndependent = false;
+    // The probe only matters on the rect-fit branch (VOD or media
+    // element mode) and measures the main container - fullscreen and
+    // PiP are viewport-sized.
+    if (
+      !isFullscreen &&
+      !canvasOutput &&
+      output &&
+      this._layoutMgr.heightNeedsProbe()
+    ) {
+      heightIndependent = containerHeightIndependent(this._container, output);
     }
     let cssProps = this._layoutMgr.fullLayout(
       rect.width,
@@ -637,14 +647,12 @@ export class UI {
       this._mode,
       isFullscreen,
       this._mediaElementMode,
-      parentHeightDefinite,
+      heightIndependent,
     );
     if (cssProps) {
       let container = pipMode ? this._pipContainer : this._container;
       container.style.width = cssProps.container.width;
       container.style.height = cssProps.container.height;
-      const canvasOutput = this._mode === MODE.LIVE && !this._mediaElementMode;
-      let output = canvasOutput ? this._canvas : this._mediaElement;
       output.style.width = cssProps.output.width;
       output.style.height = cssProps.output.height;
       output.style["object-fit"] = cssProps.output["object-fit"];
@@ -670,12 +678,6 @@ export class UI {
       }
       this._updateCanvasSize();
     }
-  }
-
-  _isParentHeightDefinite() {
-    const parent = this._container.parentElement;
-    if (!parent) return false;
-    return probeParentHeightDefinite(parent);
   }
 
   _updateCanvasSize() {

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -10,6 +10,7 @@ import { UIThumbnailPreview } from "./thumbnail-preview";
 import { UICaptionController } from "./caption-controller";
 import { UICaptionList } from "./caption-list";
 import { UILayoutManager } from "./layout-manager";
+import { probeParentHeightDefinite } from "./height-probe";
 import { UiPip } from "./ui-pip";
 import { MODE } from "@/shared/values";
 import OffscreenRendererWorker from "./offscreen-renderer-worker.js?worker";
@@ -674,44 +675,7 @@ export class UI {
   _isParentHeightDefinite() {
     const parent = this._container.parentElement;
     if (!parent) return false;
-    // A percentage height resolves only against a definite containing
-    // block, and definiteness is recursive (the parent may itself be a
-    // percentage of an auto-height ancestor) - so ask the layout engine
-    // with an in-flow probe: offsetHeight stays 0 exactly when the
-    // percentage fails to resolve. Every box property is pinned with
-    // inline !important declarations, which outrank any host stylesheet
-    // rule (including stylesheet !important), so page CSS matching the
-    // probe div (padding, borders, min-height, ...) cannot fake a
-    // definite verdict. flex:0 0 auto keeps a column flex parent from
-    // shrinking the probe. A definite height of exactly 0 still reads
-    // as indefinite - unavoidable with any measurement, and it routes a
-    // zero-sized (invisible) player to the stable branch. The
-    // synchronous append/measure/remove never reaches a rendering step,
-    // so the ResizeObserver does not see it.
-    const probe = document.createElement("div");
-    const probeStyles = {
-      position: "static",
-      display: "block",
-      "box-sizing": "border-box",
-      height: "100%",
-      width: "0",
-      "min-height": "0",
-      "max-height": "none",
-      margin: "0",
-      padding: "0",
-      border: "none",
-      flex: "0 0 auto",
-      "align-self": "auto",
-      transform: "none",
-      visibility: "hidden",
-    };
-    for (const [prop, value] of Object.entries(probeStyles)) {
-      probe.style.setProperty(prop, value, "important");
-    }
-    parent.appendChild(probe);
-    const definite = probe.offsetHeight > 0;
-    probe.remove();
-    return definite;
+    return probeParentHeightDefinite(parent);
   }
 
   _updateCanvasSize() {

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -656,6 +656,14 @@ export class UI {
           if (!this._container.isConnected) return;
           this._updateLayout(this._container.getBoundingClientRect());
         });
+        if (!this._probeRetryPending) {
+          // Nothing to wait for after all (the transitions vanished
+          // between reads) - measure again right away.
+          const reprobed = containerHeightIndependent(this._container, output);
+          if (reprobed !== null) {
+            this._heightIndependent = reprobed;
+          }
+        }
       }
       heightIndependent = this._heightIndependent ?? false;
     }

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -639,7 +639,13 @@ export class UI {
       output &&
       this._layoutMgr.heightNeedsProbe()
     ) {
-      heightIndependent = containerHeightIndependent(this._container, output);
+      const probed = containerHeightIndependent(this._container, output);
+      if (probed !== null) {
+        // null means the probe deferred (a transition is running on
+        // the output); keep the last verdict until it can re-measure.
+        this._heightIndependent = probed;
+      }
+      heightIndependent = this._heightIndependent ?? false;
     }
     let cssProps = this._layoutMgr.fullLayout(
       rect.width,

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -625,12 +625,18 @@ export class UI {
   }
 
   _resizeAndRedraw(rect, pipMode) {
+    const isFullscreen = pipMode || this._isPlayerFullscreen();
+    let parentHeightDefinite = false;
+    if (!isFullscreen && this._layoutMgr.heightNeedsParentProbe()) {
+      parentHeightDefinite = this._isParentHeightDefinite();
+    }
     let cssProps = this._layoutMgr.fullLayout(
       rect.width,
       rect.height,
       this._mode,
-      pipMode || this._isPlayerFullscreen(),
+      isFullscreen,
       this._mediaElementMode,
+      parentHeightDefinite,
     );
     if (cssProps) {
       let container = pipMode ? this._pipContainer : this._container;
@@ -663,6 +669,24 @@ export class UI {
       }
       this._updateCanvasSize();
     }
+  }
+
+  _isParentHeightDefinite() {
+    const parent = this._container.parentElement;
+    if (!parent) return false;
+    // A percentage height resolves only against a definite containing
+    // block, and definiteness is recursive (the parent may itself be a
+    // percentage of an auto-height ancestor) - so ask the layout engine
+    // with an in-flow probe. flex-shrink:0 keeps the probe from
+    // collapsing inside a column flex parent. The synchronous
+    // append/measure/remove never reaches a rendering step, so the
+    // ResizeObserver does not see it.
+    const probe = document.createElement("div");
+    probe.style.cssText = "height:100%;width:0;visibility:hidden;flex-shrink:0";
+    parent.appendChild(probe);
+    const definite = probe.offsetHeight > 0;
+    probe.remove();
+    return definite;
   }
 
   _updateCanvasSize() {

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -10,7 +10,10 @@ import { UIThumbnailPreview } from "./thumbnail-preview";
 import { UICaptionController } from "./caption-controller";
 import { UICaptionList } from "./caption-list";
 import { UILayoutManager } from "./layout-manager";
-import { containerHeightIndependent } from "./height-probe";
+import {
+  containerHeightIndependent,
+  whenOutputTransitionsSettled,
+} from "./height-probe";
 import { UiPip } from "./ui-pip";
 import { MODE } from "@/shared/values";
 import OffscreenRendererWorker from "./offscreen-renderer-worker.js?worker";
@@ -641,9 +644,18 @@ export class UI {
     ) {
       const probed = containerHeightIndependent(this._container, output);
       if (probed !== null) {
-        // null means the probe deferred (a transition is running on
-        // the output); keep the last verdict until it can re-measure.
         this._heightIndependent = probed;
+      } else if (!this._probeRetryPending) {
+        // The probe deferred because a CSS transition is live on the
+        // output. Keep the last verdict for now, and re-run the layout
+        // once the transitions settle - a transition that never
+        // resizes the container (an opacity fade) produces no resize
+        // events, so without this the stale verdict would stick.
+        this._probeRetryPending = whenOutputTransitionsSettled(output, () => {
+          this._probeRetryPending = false;
+          if (!this._container.isConnected) return;
+          this._updateLayout(this._container.getBoundingClientRect());
+        });
       }
       heightIndependent = this._heightIndependent ?? false;
     }

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -677,12 +677,37 @@ export class UI {
     // A percentage height resolves only against a definite containing
     // block, and definiteness is recursive (the parent may itself be a
     // percentage of an auto-height ancestor) - so ask the layout engine
-    // with an in-flow probe. flex-shrink:0 keeps the probe from
-    // collapsing inside a column flex parent. The synchronous
-    // append/measure/remove never reaches a rendering step, so the
-    // ResizeObserver does not see it.
+    // with an in-flow probe: offsetHeight stays 0 exactly when the
+    // percentage fails to resolve. Every box property is pinned with
+    // inline !important declarations, which outrank any host stylesheet
+    // rule (including stylesheet !important), so page CSS matching the
+    // probe div (padding, borders, min-height, ...) cannot fake a
+    // definite verdict. flex:0 0 auto keeps a column flex parent from
+    // shrinking the probe. A definite height of exactly 0 still reads
+    // as indefinite - unavoidable with any measurement, and it routes a
+    // zero-sized (invisible) player to the stable branch. The
+    // synchronous append/measure/remove never reaches a rendering step,
+    // so the ResizeObserver does not see it.
     const probe = document.createElement("div");
-    probe.style.cssText = "height:100%;width:0;visibility:hidden;flex-shrink:0";
+    const probeStyles = {
+      position: "static",
+      display: "block",
+      "box-sizing": "border-box",
+      height: "100%",
+      width: "0",
+      "min-height": "0",
+      "max-height": "none",
+      margin: "0",
+      padding: "0",
+      border: "none",
+      flex: "0 0 auto",
+      "align-self": "auto",
+      transform: "none",
+      visibility: "hidden",
+    };
+    for (const [prop, value] of Object.entries(probeStyles)) {
+      probe.style.setProperty(prop, value, "important");
+    }
     parent.appendChild(probe);
     const definite = probe.offsetHeight > 0;
     probe.remove();

--- a/tests/browser/height-probe.test.js
+++ b/tests/browser/height-probe.test.js
@@ -651,6 +651,50 @@ describe("containerHeightIndependent", () => {
     expect(scroller.scrollTop).toBe(250);
   });
 
+  it("restores a smooth-behavior scroller instantly", () => {
+    // The restore must not glide: behavior:"instant" bypasses a host
+    // `scroll-behavior: smooth` on engines that keep the clamped
+    // offset. Pinned here; Chromium restores within the task anyway.
+    const scroller = document.createElement("div");
+    scroller.style.cssText =
+      "height:200px;overflow:auto;scroll-behavior:smooth";
+    const spacer = document.createElement("div");
+    spacer.style.cssText = "height:300px";
+    scroller.appendChild(spacer);
+    root.appendChild(scroller);
+
+    const parent = document.createElement("div");
+    parent.style.cssText = "display:block;width:400px";
+    scroller.appendChild(parent);
+    const container = document.createElement("div");
+    Object.assign(container.style, {
+      display: "block",
+      position: "relative",
+      width: "100%",
+      height: "100%",
+    });
+    parent.appendChild(container);
+    const canvas = document.createElement("canvas");
+    canvas.width = 1280;
+    canvas.height = 720;
+    Object.assign(canvas.style, {
+      display: "block",
+      width: "100%",
+      height: "225px",
+    });
+    container.appendChild(canvas);
+
+    // Even the setup needs behavior:"instant" - a plain scrollTop
+    // assignment on a smooth scroller animates and reads back 0.
+    scroller.scrollTo({ top: 250, behavior: "instant" });
+    expect(scroller.scrollTop).toBe(250);
+
+    containerHeightIndependent(container, canvas);
+
+    // Synchronously back at the exact offset - no smooth glide pending.
+    expect(scroller.scrollTop).toBe(250);
+  });
+
   it("preserves ancestor scroll positions", () => {
     // Finding: the 1px pass shrinks an overflowing ancestor's scroll
     // range, and the browser's scrollTop clamp survives restoration.

--- a/tests/browser/height-probe.test.js
+++ b/tests/browser/height-probe.test.js
@@ -1,24 +1,28 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { probeParentHeightDefinite } from "@/ui/height-probe";
+import { containerHeightIndependent } from "@/ui/height-probe";
 
-// Exercises the production probe against a real layout engine - the
-// definiteness verdict depends on CSS resolution that jsdom cannot
-// compute. Hostile rules replicate host pages that style their
-// wrapper's direct children, which contaminated the offsetHeight of an
-// unstyled probe before it pinned its box properties with !important.
+// Exercises the production probe against a real layout engine. The
+// probe flips the existing output element's inline height and checks
+// whether the container's height follows - measuring the feedback
+// loop itself, with no inserted element. That makes it immune to the
+// vectors that broke element-insertion probes: pseudo-element rules on
+// empty children, and structural selectors (:empty, :has, :nth-child)
+// reacting to a temporary child.
 const HOSTILE_CSS = `
-  .hostile > div {
-    min-height: 40px;
-    padding: 12px;
-    border: 6px solid red;
+  .hostile-pseudo > div:empty::before {
+    content: "";
+    display: block;
+    height: 40px;
   }
-  .hostile-important > div {
-    min-height: 40px !important;
-    padding: 12px !important;
+  .hostile-has:has(> :nth-child(2)) {
+    height: 300px;
+  }
+  .hostile-transition canvas {
+    transition: height 1s linear;
   }
 `;
 
-describe("probeParentHeightDefinite", () => {
+describe("containerHeightIndependent", () => {
   let root;
   let styleTag;
 
@@ -35,7 +39,10 @@ describe("probeParentHeightDefinite", () => {
     styleTag.remove();
   });
 
-  function makeParent({ parentCss, ancestorCss, parentClass, fillers = 1 }) {
+  // Builds the production DOM shape: a parent (host page), the nimio
+  // container with the configured css height inline, and a canvas
+  // output inside it.
+  function build({ parentCss, height, ancestorCss, parentClass, vars }) {
     let mount = root;
     if (ancestorCss !== undefined) {
       const ancestor = document.createElement("div");
@@ -46,109 +53,251 @@ describe("probeParentHeightDefinite", () => {
     const parent = document.createElement("div");
     parent.style.cssText = parentCss;
     if (parentClass) parent.className = parentClass;
-    // Content stands in for the player container, so auto-height
-    // parents are non-empty just like in production.
-    for (let i = 0; i < fillers; i++) {
-      const filler = document.createElement("div");
-      filler.style.cssText = "height:80px;width:100px";
-      parent.appendChild(filler);
+    for (const [name, value] of Object.entries(vars ?? {})) {
+      parent.style.setProperty(name, value);
     }
     mount.appendChild(parent);
-    return parent;
+
+    const container = document.createElement("div");
+    Object.assign(container.style, {
+      display: "block",
+      position: "relative",
+      width: "100%",
+      height,
+    });
+    parent.appendChild(container);
+
+    const canvas = document.createElement("canvas");
+    canvas.width = 1280;
+    canvas.height = 720;
+    Object.assign(canvas.style, {
+      display: "block",
+      width: "100%",
+      height: "100%",
+    });
+    container.appendChild(canvas);
+
+    return { parent, container, canvas };
   }
 
   const CASES = [
-    ["block, no height", { parentCss: "display:block" }, false],
-    ["block, height:300px", { parentCss: "display:block;height:300px" }, true],
-    ["block, height:50vh", { parentCss: "display:block;height:50vh" }, true],
     [
-      "block, height:100% of a heightless ancestor",
-      { parentCss: "display:block;height:100%", ancestorCss: "display:block" },
+      "100% in a heightless block parent",
+      { parentCss: "display:block", height: "100%" },
       false,
     ],
     [
-      "block, height:100% of a 300px ancestor",
+      "100% in a 300px block parent",
+      { parentCss: "display:block;height:300px", height: "100%" },
+      true,
+    ],
+    [
+      "100% of 100% of a heightless ancestor",
+      {
+        parentCss: "display:block;height:100%",
+        ancestorCss: "display:block",
+        height: "100%",
+      },
+      false,
+    ],
+    [
+      "100% of 100% of a 300px ancestor",
       {
         parentCss: "display:block;height:100%",
         ancestorCss: "display:block;height:300px",
+        height: "100%",
       },
       true,
     ],
     [
-      "flex row, no height",
-      { parentCss: "display:flex;flex-direction:row" },
+      "100% in a heightless flex row parent",
+      { parentCss: "display:flex;flex-direction:row", height: "100%" },
       false,
     ],
     [
-      "flex row, height:300px",
-      { parentCss: "display:flex;flex-direction:row;height:300px" },
+      "100% in a 300px flex row parent",
+      {
+        parentCss:
+          "display:flex;flex-direction:row;height:300px;align-items:flex-start",
+        height: "100%",
+      },
       true,
     ],
     [
-      "flex column, no height",
-      { parentCss: "display:flex;flex-direction:column" },
+      "100% in a heightless flex column parent",
+      { parentCss: "display:flex;flex-direction:column", height: "100%" },
       false,
     ],
     [
-      "flex column, height:300px",
-      { parentCss: "display:flex;flex-direction:column;height:300px" },
-      true,
-    ],
-    [
-      "flex column, height:300px with shrink pressure",
+      "100% in a 300px flex column parent",
       {
         parentCss: "display:flex;flex-direction:column;height:300px",
-        fillers: 5,
+        height: "100%",
       },
       true,
     ],
-    ["grid, no height", { parentCss: "display:grid" }, false],
-    ["grid, height:300px", { parentCss: "display:grid;height:300px" }, true],
     [
-      "hostile child CSS, block, no height",
-      { parentCss: "display:block", parentClass: "hostile" },
+      "100% in a heightless grid parent",
+      { parentCss: "display:grid", height: "100%" },
+      false,
+    ],
+    // An implicit auto row is stretched to the grid's 300px only while
+    // the content fits; a larger output grows the row, so the feedback
+    // loop is real and "content-sized" is the safe, correct verdict
+    // (the old parent probe called this definite).
+    [
+      "100% in a 300px grid parent with an auto row",
+      { parentCss: "display:grid;height:300px", height: "100%" },
       false,
     ],
     [
-      "hostile child CSS, block, height:300px",
-      { parentCss: "display:block;height:300px", parentClass: "hostile" },
-      true,
-    ],
-    [
-      "hostile !important child CSS, block, no height",
-      { parentCss: "display:block", parentClass: "hostile-important" },
-      false,
-    ],
-    [
-      "hostile child CSS, flex column, no height",
+      "100% in a 300px grid parent with a definite row",
       {
-        parentCss: "display:flex;flex-direction:column",
-        parentClass: "hostile",
+        parentCss: "display:grid;height:300px;grid-template-rows:100%",
+        height: "100%",
+      },
+      true,
+    ],
+    // Finding: var() must be judged by its resolved value, not by the
+    // parent - an auto-valued variable in a definite parent is still
+    // content-sized and would oscillate under the rect fit.
+    [
+      "var() resolving to auto in a 300px parent",
+      {
+        parentCss: "display:block;height:300px",
+        height: "var(--player-height)",
+        vars: { "--player-height": "auto" },
       },
       false,
     ],
-    // Accepted degenerate: a definite 0 is indistinguishable from an
-    // unresolved percentage by measurement; "indefinite" routes a
-    // zero-sized (invisible) player to the stable branch.
     [
-      "block, height:0 reads as indefinite",
-      { parentCss: "display:block;height:0" },
+      "var() resolving to 480px in a heightless parent",
+      {
+        parentCss: "display:block",
+        height: "var(--player-height)",
+        vars: { "--player-height": "480px" },
+      },
+      true,
+    ],
+    [
+      "var() resolving to 100% in a heightless parent",
+      {
+        parentCss: "display:block",
+        height: "var(--player-height)",
+        vars: { "--player-height": "100%" },
+      },
       false,
+    ],
+    [
+      "undefined var() in a 300px parent",
+      {
+        parentCss: "display:block;height:300px",
+        height: "var(--player-height)",
+      },
+      false,
+    ],
+    [
+      "inherit from a 300px parent",
+      { parentCss: "display:block;height:300px", height: "inherit" },
+      true,
+    ],
+    [
+      "inherit from a heightless parent",
+      { parentCss: "display:block", height: "inherit" },
+      false,
+    ],
+    [
+      "calc(100% - 40px) in a 300px parent",
+      { parentCss: "display:block;height:300px", height: "calc(100% - 40px)" },
+      true,
+    ],
+    [
+      "calc(100% - 40px) in a heightless parent",
+      { parentCss: "display:block", height: "calc(100% - 40px)" },
+      false,
+    ],
+    // Finding: pseudo-element rules on empty children fooled the
+    // element-insertion probe; nothing is inserted now.
+    [
+      "hostile :empty::before rule, 100% in a heightless parent",
+      {
+        parentCss: "display:block",
+        parentClass: "hostile-pseudo",
+        height: "100%",
+      },
+      false,
+    ],
+    [
+      "hostile :empty::before rule, 100% in a 300px parent",
+      {
+        parentCss: "display:block;height:300px",
+        parentClass: "hostile-pseudo",
+        height: "100%",
+      },
+      true,
+    ],
+    // Finding: a :has(> :nth-child(2)) rule gave the parent a height
+    // only while a temporary child existed; the steady state (one
+    // child) must decide.
+    [
+      "hostile :has(> :nth-child(2)) rule, 100% in a heightless parent",
+      {
+        parentCss: "display:block",
+        parentClass: "hostile-has",
+        height: "100%",
+      },
+      false,
+    ],
+    [
+      "host transition on the output, 100% in a heightless parent",
+      {
+        parentCss: "display:block",
+        parentClass: "hostile-transition",
+        height: "100%",
+      },
+      false,
+    ],
+    // Improvement over the parent probe: a definite 0 is now
+    // measurable - the container height stays 0 whatever the output
+    // does, so the rect fit is safe.
+    [
+      "100% in a definite zero-height parent",
+      { parentCss: "display:block;height:0", height: "100%" },
+      true,
     ],
   ];
 
   for (const [name, setup, expected] of CASES) {
-    it(`${name} -> ${expected ? "definite" : "indefinite"}`, () => {
-      expect(probeParentHeightDefinite(makeParent(setup))).toBe(expected);
+    it(`${name} -> ${expected ? "independent" : "content-sized"}`, () => {
+      const { container, canvas } = build(setup);
+      expect(containerHeightIndependent(container, canvas)).toBe(expected);
     });
   }
 
-  it("leaves no probe element behind", () => {
-    const parent = makeParent({ parentCss: "display:block;height:300px" });
-    const before = parent.childNodes.length;
+  it("does not mutate the DOM structure", () => {
+    const { parent, container, canvas } = build({
+      parentCss: "display:block;height:300px",
+      height: "100%",
+    });
+    const parentChildren = parent.childNodes.length;
+    const containerChildren = container.childNodes.length;
 
-    probeParentHeightDefinite(parent);
+    containerHeightIndependent(container, canvas);
 
-    expect(parent.childNodes.length).toBe(before);
+    expect(parent.childNodes.length).toBe(parentChildren);
+    expect(container.childNodes.length).toBe(containerChildren);
+  });
+
+  it("restores the output's inline styles exactly", () => {
+    const { container, canvas } = build({
+      parentCss: "display:block;height:300px",
+      height: "100%",
+    });
+    canvas.style.setProperty("height", "55%", "important");
+    const before = canvas.style.cssText;
+
+    containerHeightIndependent(container, canvas);
+
+    expect(canvas.style.cssText).toBe(before);
   });
 });

--- a/tests/browser/height-probe.test.js
+++ b/tests/browser/height-probe.test.js
@@ -216,6 +216,32 @@ describe("containerHeightIndependent", () => {
       { parentCss: "display:block", height: "calc(100% - 40px)" },
       false,
     ],
+    // Finding: env() with a fallback can resolve to auto, and
+    // calc-size(auto, ...) keeps intrinsic sizing - both must be
+    // measured, not assumed definite. (If the browser rejects the
+    // syntax the height falls back to auto, so the expected verdict
+    // holds either way.)
+    [
+      "env() falling back to auto in a 300px parent",
+      {
+        parentCss: "display:block;height:300px",
+        height: "env(missing-env-var, auto)",
+      },
+      false,
+    ],
+    [
+      "calc-size(auto, size) in a 300px parent",
+      {
+        parentCss: "display:block;height:300px",
+        height: "calc-size(auto, size)",
+      },
+      false,
+    ],
+    [
+      "calc(50vh - 10px) in a heightless parent",
+      { parentCss: "display:block", height: "calc(50vh - 10px)" },
+      true,
+    ],
     // Finding: pseudo-element rules on empty children fooled the
     // element-insertion probe; nothing is inserted now.
     [
@@ -299,5 +325,64 @@ describe("containerHeightIndependent", () => {
     containerHeightIndependent(container, canvas);
 
     expect(canvas.style.cssText).toBe(before);
+  });
+
+  it("does not start a host transition when restoring the output", async () => {
+    // Finding: restoring cssText with a host height transition active
+    // made the next style change animate from the 99999px probe value.
+    const { container, canvas } = build({
+      parentCss: "display:block",
+      parentClass: "hostile-transition",
+      height: "100%",
+    });
+    const steady = canvas.offsetHeight;
+    let transitions = 0;
+    canvas.addEventListener("transitionstart", () => transitions++);
+
+    containerHeightIndependent(container, canvas);
+
+    expect(canvas.offsetHeight).toBe(steady);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(transitions).toBe(0);
+    expect(canvas.offsetHeight).toBe(steady);
+  });
+
+  it("preserves ancestor scroll positions", () => {
+    // Finding: the 1px pass shrinks an overflowing ancestor's scroll
+    // range, and the browser's scrollTop clamp survives restoration.
+    const scroller = document.createElement("div");
+    scroller.style.cssText = "height:200px;overflow:auto";
+    const spacer = document.createElement("div");
+    spacer.style.cssText = "height:300px";
+    scroller.appendChild(spacer);
+    root.appendChild(scroller);
+
+    const parent = document.createElement("div");
+    parent.style.cssText = "display:block;width:400px";
+    scroller.appendChild(parent);
+    const container = document.createElement("div");
+    Object.assign(container.style, {
+      display: "block",
+      position: "relative",
+      width: "100%",
+      height: "100%",
+    });
+    parent.appendChild(container);
+    const canvas = document.createElement("canvas");
+    canvas.width = 1280;
+    canvas.height = 720;
+    Object.assign(canvas.style, {
+      display: "block",
+      width: "100%",
+      height: "225px",
+    });
+    container.appendChild(canvas);
+
+    scroller.scrollTop = 250;
+    expect(scroller.scrollTop).toBe(250);
+
+    containerHeightIndependent(container, canvas);
+
+    expect(scroller.scrollTop).toBe(250);
   });
 });

--- a/tests/browser/height-probe.test.js
+++ b/tests/browser/height-probe.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { probeParentHeightDefinite } from "@/ui/height-probe";
+
+// Exercises the production probe against a real layout engine - the
+// definiteness verdict depends on CSS resolution that jsdom cannot
+// compute. Hostile rules replicate host pages that style their
+// wrapper's direct children, which contaminated the offsetHeight of an
+// unstyled probe before it pinned its box properties with !important.
+const HOSTILE_CSS = `
+  .hostile > div {
+    min-height: 40px;
+    padding: 12px;
+    border: 6px solid red;
+  }
+  .hostile-important > div {
+    min-height: 40px !important;
+    padding: 12px !important;
+  }
+`;
+
+describe("probeParentHeightDefinite", () => {
+  let root;
+  let styleTag;
+
+  beforeEach(() => {
+    styleTag = document.createElement("style");
+    styleTag.textContent = HOSTILE_CSS;
+    document.head.appendChild(styleTag);
+    root = document.createElement("div");
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => {
+    root.remove();
+    styleTag.remove();
+  });
+
+  function makeParent({ parentCss, ancestorCss, parentClass, fillers = 1 }) {
+    let mount = root;
+    if (ancestorCss !== undefined) {
+      const ancestor = document.createElement("div");
+      ancestor.style.cssText = ancestorCss;
+      root.appendChild(ancestor);
+      mount = ancestor;
+    }
+    const parent = document.createElement("div");
+    parent.style.cssText = parentCss;
+    if (parentClass) parent.className = parentClass;
+    // Content stands in for the player container, so auto-height
+    // parents are non-empty just like in production.
+    for (let i = 0; i < fillers; i++) {
+      const filler = document.createElement("div");
+      filler.style.cssText = "height:80px;width:100px";
+      parent.appendChild(filler);
+    }
+    mount.appendChild(parent);
+    return parent;
+  }
+
+  const CASES = [
+    ["block, no height", { parentCss: "display:block" }, false],
+    ["block, height:300px", { parentCss: "display:block;height:300px" }, true],
+    ["block, height:50vh", { parentCss: "display:block;height:50vh" }, true],
+    [
+      "block, height:100% of a heightless ancestor",
+      { parentCss: "display:block;height:100%", ancestorCss: "display:block" },
+      false,
+    ],
+    [
+      "block, height:100% of a 300px ancestor",
+      {
+        parentCss: "display:block;height:100%",
+        ancestorCss: "display:block;height:300px",
+      },
+      true,
+    ],
+    [
+      "flex row, no height",
+      { parentCss: "display:flex;flex-direction:row" },
+      false,
+    ],
+    [
+      "flex row, height:300px",
+      { parentCss: "display:flex;flex-direction:row;height:300px" },
+      true,
+    ],
+    [
+      "flex column, no height",
+      { parentCss: "display:flex;flex-direction:column" },
+      false,
+    ],
+    [
+      "flex column, height:300px",
+      { parentCss: "display:flex;flex-direction:column;height:300px" },
+      true,
+    ],
+    [
+      "flex column, height:300px with shrink pressure",
+      {
+        parentCss: "display:flex;flex-direction:column;height:300px",
+        fillers: 5,
+      },
+      true,
+    ],
+    ["grid, no height", { parentCss: "display:grid" }, false],
+    ["grid, height:300px", { parentCss: "display:grid;height:300px" }, true],
+    [
+      "hostile child CSS, block, no height",
+      { parentCss: "display:block", parentClass: "hostile" },
+      false,
+    ],
+    [
+      "hostile child CSS, block, height:300px",
+      { parentCss: "display:block;height:300px", parentClass: "hostile" },
+      true,
+    ],
+    [
+      "hostile !important child CSS, block, no height",
+      { parentCss: "display:block", parentClass: "hostile-important" },
+      false,
+    ],
+    [
+      "hostile child CSS, flex column, no height",
+      {
+        parentCss: "display:flex;flex-direction:column",
+        parentClass: "hostile",
+      },
+      false,
+    ],
+    // Accepted degenerate: a definite 0 is indistinguishable from an
+    // unresolved percentage by measurement; "indefinite" routes a
+    // zero-sized (invisible) player to the stable branch.
+    [
+      "block, height:0 reads as indefinite",
+      { parentCss: "display:block;height:0" },
+      false,
+    ],
+  ];
+
+  for (const [name, setup, expected] of CASES) {
+    it(`${name} -> ${expected ? "definite" : "indefinite"}`, () => {
+      expect(probeParentHeightDefinite(makeParent(setup))).toBe(expected);
+    });
+  }
+
+  it("leaves no probe element behind", () => {
+    const parent = makeParent({ parentCss: "display:block;height:300px" });
+    const before = parent.childNodes.length;
+
+    probeParentHeightDefinite(parent);
+
+    expect(parent.childNodes.length).toBe(before);
+  });
+});

--- a/tests/browser/height-probe.test.js
+++ b/tests/browser/height-probe.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { containerHeightIndependent } from "@/ui/height-probe";
+import {
+  containerHeightIndependent,
+  whenOutputTransitionsSettled,
+} from "@/ui/height-probe";
 
 // Exercises the production probe against a real layout engine. The
 // probe flips the existing output element's inline height and checks
@@ -389,6 +392,41 @@ describe("containerHeightIndependent", () => {
     expect(midFlight).toBeLessThan(400);
   });
 
+  it("defers for a paused transition and leaves it intact", async () => {
+    // Finding: a paused transition has playState "paused", but pinning
+    // transition:none destroys it just the same - presence of any
+    // CSSTransition must defer the probe.
+    const { container, canvas } = build({
+      parentCss: "display:block",
+      parentClass: "hostile-transition",
+      height: "100%",
+    });
+    canvas.style.height = "50px";
+    void canvas.offsetHeight;
+    canvas.style.height = "400px";
+    await new Promise((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(resolve)),
+    );
+    const transition = canvas
+      .getAnimations()
+      .find((a) => a.transitionProperty === "height");
+    expect(transition).toBeDefined();
+    transition.pause();
+    let cancelled = 0;
+    canvas.addEventListener("transitioncancel", () => cancelled++);
+
+    const verdict = containerHeightIndependent(container, canvas);
+
+    expect(verdict).toBeNull();
+    expect(cancelled).toBe(0);
+    expect(
+      canvas.getAnimations().some((a) => a.transitionProperty === "height"),
+    ).toBe(true);
+    const paused = canvas.getBoundingClientRect().height;
+    expect(paused).toBeGreaterThan(0);
+    expect(paused).toBeLessThan(400);
+  });
+
   it("restores styles and scroll even when measurement throws", () => {
     // Finding: cleanup must be exception-safe.
     const { container, canvas } = build({
@@ -407,6 +445,83 @@ describe("containerHeightIndependent", () => {
     );
 
     expect(canvas.style.cssText).toBe(before);
+  });
+
+  it("signals settlement of output transitions so deferred probes can retry", async () => {
+    // Finding: an opacity fade defers the probe but never resizes the
+    // container, so no ResizeObserver event retries it - the caller
+    // needs an explicit signal when the transitions are done.
+    const { container, canvas } = build({
+      parentCss: "display:block;height:300px",
+      height: "100%",
+    });
+    canvas.style.transition = "opacity 0.15s linear";
+    void canvas.offsetHeight;
+    canvas.style.opacity = "0.5";
+    await new Promise((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(resolve)),
+    );
+    expect(containerHeightIndependent(container, canvas)).toBeNull();
+
+    const settled = new Promise((resolve) => {
+      expect(whenOutputTransitionsSettled(canvas, resolve)).toBe(true);
+    });
+    await settled;
+
+    expect(containerHeightIndependent(container, canvas)).toBe(true);
+  });
+
+  it("returns false from the settle hook when nothing is transitioning", () => {
+    const { canvas } = build({
+      parentCss: "display:block;height:300px",
+      height: "100%",
+    });
+
+    expect(whenOutputTransitionsSettled(canvas, () => {})).toBe(false);
+  });
+
+  it("preserves scroll positions around a slot inside a shadow tree", () => {
+    // Finding: slotted content must walk into its assigned slot's
+    // shadow-tree ancestry - parentElement alone skips a scroller
+    // wrapping the slot.
+    const host = document.createElement("div");
+    root.appendChild(host);
+    const shadow = host.attachShadow({ mode: "open" });
+    const scroller = document.createElement("div");
+    scroller.style.cssText = "height:200px;overflow:auto";
+    const spacer = document.createElement("div");
+    spacer.style.cssText = "height:300px";
+    scroller.appendChild(spacer);
+    scroller.appendChild(document.createElement("slot"));
+    shadow.appendChild(scroller);
+
+    const parent = document.createElement("div");
+    parent.style.cssText = "display:block;width:400px";
+    host.appendChild(parent); // slotted into the scroller
+    const container = document.createElement("div");
+    Object.assign(container.style, {
+      display: "block",
+      position: "relative",
+      width: "100%",
+      height: "100%",
+    });
+    parent.appendChild(container);
+    const canvas = document.createElement("canvas");
+    canvas.width = 1280;
+    canvas.height = 720;
+    Object.assign(canvas.style, {
+      display: "block",
+      width: "100%",
+      height: "225px",
+    });
+    container.appendChild(canvas);
+
+    scroller.scrollTop = 250;
+    expect(scroller.scrollTop).toBe(250);
+
+    containerHeightIndependent(container, canvas);
+
+    expect(scroller.scrollTop).toBe(250);
   });
 
   it("preserves scroll positions across shadow-root boundaries", () => {

--- a/tests/browser/height-probe.test.js
+++ b/tests/browser/height-probe.test.js
@@ -23,6 +23,9 @@ const HOSTILE_CSS = `
   .hostile-transition canvas {
     transition: height 1s linear;
   }
+  .revert-target {
+    height: 300px;
+  }
 `;
 
 describe("containerHeightIndependent", () => {
@@ -45,7 +48,14 @@ describe("containerHeightIndependent", () => {
   // Builds the production DOM shape: a parent (host page), the nimio
   // container with the configured css height inline, and a canvas
   // output inside it.
-  function build({ parentCss, height, ancestorCss, parentClass, vars }) {
+  function build({
+    parentCss,
+    height,
+    ancestorCss,
+    parentClass,
+    vars,
+    containerClass,
+  }) {
     let mount = root;
     if (ancestorCss !== undefined) {
       const ancestor = document.createElement("div");
@@ -62,6 +72,7 @@ describe("containerHeightIndependent", () => {
     mount.appendChild(parent);
 
     const container = document.createElement("div");
+    if (containerClass) container.className = containerClass;
     Object.assign(container.style, {
       display: "block",
       position: "relative",
@@ -244,6 +255,29 @@ describe("containerHeightIndependent", () => {
       "calc(50vh - 10px) in a heightless parent",
       { parentCss: "display:block", height: "calc(50vh - 10px)" },
       true,
+    ],
+    // Finding: revert-layer in the style attribute rolls back into
+    // author stylesheet rules - a lower-layer definite height must
+    // win, so the rect fit survives. Without such a rule it computes
+    // to auto.
+    [
+      "revert-layer exposing a definite stylesheet height",
+      {
+        parentCss: "display:block",
+        height: "revert-layer",
+        containerClass: "revert-target",
+      },
+      true,
+    ],
+    [
+      "revert-layer with no stylesheet height behind it",
+      { parentCss: "display:block", height: "revert-layer" },
+      false,
+    ],
+    [
+      "revert with no user-origin height behind it",
+      { parentCss: "display:block", height: "revert" },
+      false,
     ],
     // Finding: pseudo-element rules on empty children fooled the
     // element-insertion probe; nothing is inserted now.
@@ -540,6 +574,57 @@ describe("containerHeightIndependent", () => {
     const parent = document.createElement("div");
     parent.style.cssText = "display:block;width:400px";
     shadow.appendChild(parent);
+    const container = document.createElement("div");
+    Object.assign(container.style, {
+      display: "block",
+      position: "relative",
+      width: "100%",
+      height: "100%",
+    });
+    parent.appendChild(container);
+    const canvas = document.createElement("canvas");
+    canvas.width = 1280;
+    canvas.height = 720;
+    Object.assign(canvas.style, {
+      display: "block",
+      width: "100%",
+      height: "225px",
+    });
+    container.appendChild(canvas);
+
+    scroller.scrollTop = 250;
+    expect(scroller.scrollTop).toBe(250);
+
+    containerHeightIndependent(container, canvas);
+
+    expect(scroller.scrollTop).toBe(250);
+  });
+
+  it("preserves scroll positions for ancestors adopted into an iframe document", async () => {
+    // Finding: instanceof Element is realm-specific - an ancestor
+    // living in a same-origin iframe's document has a different
+    // Element prototype, and the walk must not stop there.
+    const iframe = document.createElement("iframe");
+    iframe.style.cssText = "width:500px;height:400px;border:0";
+    root.appendChild(iframe);
+    await new Promise((resolve) => {
+      if (iframe.contentDocument?.readyState === "complete") resolve();
+      else iframe.addEventListener("load", resolve, { once: true });
+    });
+    const idoc = iframe.contentDocument;
+
+    const scroller = idoc.createElement("div");
+    scroller.style.cssText = "height:200px;overflow:auto";
+    const spacer = idoc.createElement("div");
+    spacer.style.cssText = "height:300px";
+    scroller.appendChild(spacer);
+    idoc.body.appendChild(scroller);
+
+    // Elements created in THIS realm, adopted into the iframe's
+    // document - their ancestors are foreign-realm objects.
+    const parent = document.createElement("div");
+    parent.style.cssText = "display:block;width:400px";
+    scroller.appendChild(parent);
     const container = document.createElement("div");
     Object.assign(container.style, {
       display: "block",

--- a/tests/browser/height-probe.test.js
+++ b/tests/browser/height-probe.test.js
@@ -347,6 +347,110 @@ describe("containerHeightIndependent", () => {
     expect(canvas.offsetHeight).toBe(steady);
   });
 
+  it("defers measurement while a transition runs on the output", async () => {
+    // Finding: pinning transition:none cancels every running CSS
+    // transition on the output, snapping it to its end value. A live
+    // transition must survive the probe untouched - the verdict is
+    // deferred (null) and the caller reuses its previous one.
+    const { container, canvas } = build({
+      parentCss: "display:block",
+      parentClass: "hostile-transition",
+      height: "100%",
+    });
+    canvas.style.height = "50px";
+    void canvas.offsetHeight;
+    canvas.style.height = "400px";
+    await new Promise((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(resolve)),
+    );
+    expect(
+      canvas
+        .getAnimations()
+        .some(
+          (a) => a.transitionProperty === "height" && a.playState === "running",
+        ),
+    ).toBe(true);
+    let cancelled = 0;
+    canvas.addEventListener("transitioncancel", () => cancelled++);
+
+    const verdict = containerHeightIndependent(container, canvas);
+
+    expect(verdict).toBeNull();
+    expect(cancelled).toBe(0);
+    expect(
+      canvas
+        .getAnimations()
+        .some(
+          (a) => a.transitionProperty === "height" && a.playState === "running",
+        ),
+    ).toBe(true);
+    const midFlight = canvas.getBoundingClientRect().height;
+    expect(midFlight).toBeGreaterThan(0);
+    expect(midFlight).toBeLessThan(400);
+  });
+
+  it("restores styles and scroll even when measurement throws", () => {
+    // Finding: cleanup must be exception-safe.
+    const { container, canvas } = build({
+      parentCss: "display:block;height:300px",
+      height: "100%",
+    });
+    const before = canvas.style.cssText;
+    Object.defineProperty(container, "offsetHeight", {
+      get() {
+        throw new Error("layout backstop");
+      },
+    });
+
+    expect(() => containerHeightIndependent(container, canvas)).toThrow(
+      "layout backstop",
+    );
+
+    expect(canvas.style.cssText).toBe(before);
+  });
+
+  it("preserves scroll positions across shadow-root boundaries", () => {
+    // Finding: the ancestor walk must cross shadow roots via the host,
+    // or scrollers above a web component are never snapshotted.
+    const scroller = document.createElement("div");
+    scroller.style.cssText = "height:200px;overflow:auto";
+    const spacer = document.createElement("div");
+    spacer.style.cssText = "height:300px";
+    scroller.appendChild(spacer);
+    root.appendChild(scroller);
+
+    const host = document.createElement("div");
+    scroller.appendChild(host);
+    const shadow = host.attachShadow({ mode: "open" });
+    const parent = document.createElement("div");
+    parent.style.cssText = "display:block;width:400px";
+    shadow.appendChild(parent);
+    const container = document.createElement("div");
+    Object.assign(container.style, {
+      display: "block",
+      position: "relative",
+      width: "100%",
+      height: "100%",
+    });
+    parent.appendChild(container);
+    const canvas = document.createElement("canvas");
+    canvas.width = 1280;
+    canvas.height = 720;
+    Object.assign(canvas.style, {
+      display: "block",
+      width: "100%",
+      height: "225px",
+    });
+    container.appendChild(canvas);
+
+    scroller.scrollTop = 250;
+    expect(scroller.scrollTop).toBe(250);
+
+    containerHeightIndependent(container, canvas);
+
+    expect(scroller.scrollTop).toBe(250);
+  });
+
   it("preserves ancestor scroll positions", () => {
     // Finding: the 1px pass shrinks an overflowing ancestor's scroll
     // range, and the browser's scrollTop clamp survives restoration.

--- a/tests/browser/layout-convergence.test.js
+++ b/tests/browser/layout-convergence.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { MODE } from "@/shared/values";
 import { UILayoutManager } from "@/ui/layout-manager";
-import { probeParentHeightDefinite } from "@/ui/height-probe";
+import { containerHeightIndependent } from "@/ui/height-probe";
 
 // Regression tests for the VOD flicker (#86): drive the production
 // UILayoutManager and height probe through a real ResizeObserver in a
@@ -14,9 +14,12 @@ import { probeParentHeightDefinite } from "@/ui/height-probe";
 const FRAME = { width: 1280, height: 720 };
 const AR = FRAME.width / FRAME.height;
 
-function buildPlayer({ parentCss, width, height, probeFn }) {
+function buildPlayer({ parentCss, width, height, probeFn, parentVars }) {
   const parent = document.createElement("div");
   parent.style.cssText = parentCss;
+  for (const [name, value] of Object.entries(parentVars ?? {})) {
+    parent.style.setProperty(name, value);
+  }
   document.body.appendChild(parent);
 
   // Mirrors the container setup in the UI constructor.
@@ -46,14 +49,14 @@ function buildPlayer({ parentCss, width, height, probeFn }) {
   layoutMgr.setFrameSize(FRAME.width, FRAME.height);
   Object.assign(container.style, layoutMgr.containerLayout(false));
 
-  const probe = probeFn ?? probeParentHeightDefinite;
+  const probe = probeFn ?? containerHeightIndependent;
   const stats = { events: 0, applies: 0 };
 
   // Mirrors _resizeAndRedraw.
   function applyLayout(rect) {
-    let parentHeightDefinite = false;
-    if (layoutMgr.heightNeedsParentProbe()) {
-      parentHeightDefinite = probe(container.parentElement);
+    let heightIndependent = false;
+    if (layoutMgr.heightNeedsProbe()) {
+      heightIndependent = probe(container, canvas);
     }
     const cssProps = layoutMgr.fullLayout(
       rect.width,
@@ -61,7 +64,7 @@ function buildPlayer({ parentCss, width, height, probeFn }) {
       MODE.VOD,
       false,
       false,
-      parentHeightDefinite,
+      heightIndependent,
     );
     if (cssProps) {
       container.style.width = cssProps.container.width;
@@ -191,7 +194,24 @@ describe("VOD layout convergence", () => {
     expect(player.canvas.offsetWidth).toBeCloseTo(300 * AR, 0);
   });
 
-  it("self-check: a wrong definite verdict makes the harness detect oscillation", async () => {
+  it("converges with an auto-valued var() height in a fixed-height parent", async () => {
+    // Regression for the var() finding: the parent is definite, but the
+    // variable resolves to auto, so the container is content-sized and
+    // the rect fit would oscillate.
+    player = buildPlayer({
+      parentCss: "display:block;width:800px;height:300px",
+      parentVars: { "--player-height": "auto" },
+      width: "100%",
+      height: "var(--player-height)",
+    });
+
+    expect(await settles(player.stats)).toBe(true);
+    expect(player.stats.applies).toBeLessThanOrEqual(8);
+    expect(player.canvas.style.width).toBe("100%");
+    expect(player.canvas.style.height).toBe("auto");
+  });
+
+  it("self-check: a wrong independent verdict makes the harness detect oscillation", async () => {
     // Simulates the pre-fix behavior (rect fit despite an unresolvable
     // percentage) and proves this harness can catch it: if the guard
     // regresses, the convergence tests above fail the same way.

--- a/tests/browser/layout-convergence.test.js
+++ b/tests/browser/layout-convergence.test.js
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { MODE } from "@/shared/values";
+import { UILayoutManager } from "@/ui/layout-manager";
+import { probeParentHeightDefinite } from "@/ui/height-probe";
+
+// Regression tests for the VOD flicker (#86): drive the production
+// UILayoutManager and height probe through a real ResizeObserver in a
+// real layout engine and assert the loop converges to a fixed point
+// instead of oscillating. Only the thin style-application glue from
+// UI._resizeAndRedraw / _updateLayout is replicated here (building the
+// full UI needs workers and codecs); the decision logic under test is
+// all production code.
+
+const FRAME = { width: 1280, height: 720 };
+const AR = FRAME.width / FRAME.height;
+
+function buildPlayer({ parentCss, width, height, probeFn }) {
+  const parent = document.createElement("div");
+  parent.style.cssText = parentCss;
+  document.body.appendChild(parent);
+
+  // Mirrors the container setup in the UI constructor.
+  const container = document.createElement("div");
+  Object.assign(container.style, {
+    display: "block",
+    position: "relative",
+    backgroundColor: "#000",
+    alignContent: "center",
+  });
+  parent.appendChild(container);
+
+  // Mirrors ui.css `.nimio-container > canvas` and _applyBasicStyle.
+  const canvas = document.createElement("canvas");
+  canvas.width = FRAME.width;
+  canvas.height = FRAME.height;
+  Object.assign(canvas.style, {
+    display: "block",
+    width: "100%",
+    height: "100%",
+    margin: "auto",
+    position: "relative",
+  });
+  container.appendChild(canvas);
+
+  const layoutMgr = new UILayoutManager(width, height);
+  layoutMgr.setFrameSize(FRAME.width, FRAME.height);
+  Object.assign(container.style, layoutMgr.containerLayout(false));
+
+  const probe = probeFn ?? probeParentHeightDefinite;
+  const stats = { events: 0, applies: 0 };
+
+  // Mirrors _resizeAndRedraw.
+  function applyLayout(rect) {
+    let parentHeightDefinite = false;
+    if (layoutMgr.heightNeedsParentProbe()) {
+      parentHeightDefinite = probe(container.parentElement);
+    }
+    const cssProps = layoutMgr.fullLayout(
+      rect.width,
+      rect.height,
+      MODE.VOD,
+      false,
+      false,
+      parentHeightDefinite,
+    );
+    if (cssProps) {
+      container.style.width = cssProps.container.width;
+      container.style.height = cssProps.container.height;
+      canvas.style.width = cssProps.output.width;
+      canvas.style.height = cssProps.output.height;
+      canvas.style["object-fit"] = cssProps.output["object-fit"];
+      canvas.style["aspect-ratio"] = cssProps.output["aspect-ratio"];
+    }
+    stats.applies++;
+  }
+
+  // Mirrors _createResizeObserver / _updateLayout (rAF-deferred with a
+  // pending guard).
+  let pending = false;
+  const observer = new ResizeObserver((entries) => {
+    stats.events++;
+    const rect = entries[0].contentRect;
+    requestAnimationFrame(() => {
+      if (pending) return;
+      pending = true;
+      requestAnimationFrame(() => {
+        pending = false;
+        applyLayout(rect);
+      });
+    });
+  });
+  observer.observe(container);
+
+  // Mirrors the initial layout pass from _handleLayoutUpdate.
+  applyLayout(container.getBoundingClientRect());
+
+  return {
+    parent,
+    container,
+    canvas,
+    stats,
+    destroy() {
+      observer.disconnect();
+      parent.remove();
+    },
+  };
+}
+
+// Resolves true once no resize events arrive for quietMs; false if the
+// loop is still producing events when maxMs runs out (oscillation).
+async function settles(stats, { quietMs = 300, maxMs = 3000 } = {}) {
+  const start = performance.now();
+  let seen = stats.events;
+  let lastChange = performance.now();
+  for (;;) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const now = performance.now();
+    if (stats.events !== seen) {
+      seen = stats.events;
+      lastChange = now;
+    } else if (now - lastChange >= quietMs) {
+      return true;
+    }
+    if (now - start >= maxMs) return false;
+  }
+}
+
+describe("VOD layout convergence", () => {
+  let player;
+
+  beforeEach(() => {
+    player = undefined;
+  });
+
+  afterEach(() => {
+    player?.destroy();
+  });
+
+  it("converges with an auto height (the original flicker)", async () => {
+    player = buildPlayer({
+      parentCss: "display:block;width:800px",
+      width: "100%",
+      height: "auto",
+    });
+
+    expect(await settles(player.stats)).toBe(true);
+    expect(player.stats.applies).toBeLessThanOrEqual(8);
+    expect(player.canvas.style.width).toBe("100%");
+    expect(player.canvas.style.height).toBe("auto");
+    expect(player.container.offsetHeight).toBeCloseTo(800 / AR, 0);
+  });
+
+  it("converges with a percentage height in a heightless parent", async () => {
+    player = buildPlayer({
+      parentCss: "display:block;width:800px",
+      width: "100%",
+      height: "100%",
+    });
+
+    expect(await settles(player.stats)).toBe(true);
+    expect(player.stats.applies).toBeLessThanOrEqual(8);
+    expect(player.canvas.style.width).toBe("100%");
+    expect(player.canvas.style.height).toBe("auto");
+  });
+
+  it("converges with a fit-content height", async () => {
+    player = buildPlayer({
+      parentCss: "display:block;width:800px",
+      width: "100%",
+      height: "fit-content",
+    });
+
+    expect(await settles(player.stats)).toBe(true);
+    expect(player.stats.applies).toBeLessThanOrEqual(8);
+    expect(player.canvas.style.height).toBe("auto");
+  });
+
+  it("letterboxes a resolvable percentage height and stays stable", async () => {
+    player = buildPlayer({
+      parentCss: "display:block;width:800px;height:300px",
+      width: "100%",
+      height: "100%",
+    });
+
+    expect(await settles(player.stats)).toBe(true);
+    expect(player.stats.applies).toBeLessThanOrEqual(8);
+    // The rect-based fit must survive: height-constrained, aspect width.
+    expect(player.canvas.style.height).toBe("100%");
+    expect(player.canvas.style.width).toBe("auto");
+    expect(player.container.offsetHeight).toBe(300);
+    expect(player.canvas.offsetWidth).toBeCloseTo(300 * AR, 0);
+  });
+
+  it("self-check: a wrong definite verdict makes the harness detect oscillation", async () => {
+    // Simulates the pre-fix behavior (rect fit despite an unresolvable
+    // percentage) and proves this harness can catch it: if the guard
+    // regresses, the convergence tests above fail the same way.
+    player = buildPlayer({
+      parentCss: "display:block;width:800px",
+      width: "100%",
+      height: "100%",
+      probeFn: () => true,
+    });
+
+    const settled = await settles(player.stats, { maxMs: 1500 });
+
+    expect(settled).toBe(false);
+    expect(player.stats.events).toBeGreaterThan(10);
+  });
+});

--- a/tests/browser/layout-convergence.test.js
+++ b/tests/browser/layout-convergence.test.js
@@ -52,11 +52,15 @@ function buildPlayer({ parentCss, width, height, probeFn, parentVars }) {
   const probe = probeFn ?? containerHeightIndependent;
   const stats = { events: 0, applies: 0 };
 
-  // Mirrors _resizeAndRedraw.
+  // Mirrors _resizeAndRedraw (including the last-verdict cache for
+  // probes deferred by a running transition).
+  let lastVerdict;
   function applyLayout(rect) {
     let heightIndependent = false;
     if (layoutMgr.heightNeedsProbe()) {
-      heightIndependent = probe(container, canvas);
+      const probed = probe(container, canvas);
+      if (probed !== null) lastVerdict = probed;
+      heightIndependent = lastVerdict ?? false;
     }
     const cssProps = layoutMgr.fullLayout(
       rect.width,

--- a/tests/browser/layout-convergence.test.js
+++ b/tests/browser/layout-convergence.test.js
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { MODE } from "@/shared/values";
 import { UILayoutManager } from "@/ui/layout-manager";
-import { containerHeightIndependent } from "@/ui/height-probe";
+import {
+  containerHeightIndependent,
+  whenOutputTransitionsSettled,
+} from "@/ui/height-probe";
 
 // Regression tests for the VOD flicker (#86): drive the production
 // UILayoutManager and height probe through a real ResizeObserver in a
@@ -52,14 +55,23 @@ function buildPlayer({ parentCss, width, height, probeFn, parentVars }) {
   const probe = probeFn ?? containerHeightIndependent;
   const stats = { events: 0, applies: 0 };
 
-  // Mirrors _resizeAndRedraw (including the last-verdict cache for
-  // probes deferred by a running transition).
+  // Mirrors _resizeAndRedraw (including the last-verdict cache and the
+  // settled-transitions retry for deferred probes).
   let lastVerdict;
+  let retryPending = false;
   function applyLayout(rect) {
     let heightIndependent = false;
     if (layoutMgr.heightNeedsProbe()) {
       const probed = probe(container, canvas);
-      if (probed !== null) lastVerdict = probed;
+      if (probed !== null) {
+        lastVerdict = probed;
+      } else if (!retryPending) {
+        retryPending = whenOutputTransitionsSettled(canvas, () => {
+          retryPending = false;
+          if (!container.isConnected) return;
+          applyLayout(container.getBoundingClientRect());
+        });
+      }
       heightIndependent = lastVerdict ?? false;
     }
     const cssProps = layoutMgr.fullLayout(
@@ -111,6 +123,16 @@ function buildPlayer({ parentCss, width, height, probeFn, parentVars }) {
       parent.remove();
     },
   };
+}
+
+// Polls until fn() is truthy or the timeout elapses.
+async function until(fn, timeout = 3000) {
+  const start = performance.now();
+  while (performance.now() - start < timeout) {
+    if (fn()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return !!fn();
 }
 
 // Resolves true once no resize events arrive for quietMs; false if the
@@ -213,6 +235,33 @@ describe("VOD layout convergence", () => {
     expect(player.stats.applies).toBeLessThanOrEqual(8);
     expect(player.canvas.style.width).toBe("100%");
     expect(player.canvas.style.height).toBe("auto");
+  });
+
+  it("re-probes after a deferring transition ends (stale verdict recovery)", async () => {
+    // Finding: with an opacity fade live on the output, probes defer
+    // and there are no resize events to retry them - the verdict must
+    // recover through the transitions-settled hook once the fade ends.
+    player = buildPlayer({
+      parentCss: "display:block;width:800px",
+      width: "100%",
+      height: "100%",
+    });
+    expect(await settles(player.stats)).toBe(true);
+    expect(player.canvas.style.height).toBe("auto"); // content-sized verdict
+
+    // Start an opacity fade, then give the parent a definite height
+    // while it runs: the correct verdict flips to independent, but the
+    // probe cannot measure until the fade finishes.
+    player.canvas.style.transition = "opacity 0.3s linear";
+    void player.canvas.offsetHeight;
+    player.canvas.style.opacity = "0.5";
+    await new Promise((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(resolve)),
+    );
+    player.parent.style.height = "300px";
+
+    const recovered = await until(() => player.canvas.style.height === "100%");
+    expect(recovered).toBe(true);
   });
 
   it("self-check: a wrong independent verdict makes the harness detect oscillation", async () => {

--- a/tests/browser/layout-convergence.test.js
+++ b/tests/browser/layout-convergence.test.js
@@ -71,6 +71,11 @@ function buildPlayer({ parentCss, width, height, probeFn, parentVars }) {
           if (!container.isConnected) return;
           applyLayout(container.getBoundingClientRect());
         });
+        if (!retryPending) {
+          // Nothing to wait for after all - measure again right away.
+          const reprobed = probe(container, canvas);
+          if (reprobed !== null) lastVerdict = reprobed;
+        }
       }
       heightIndependent = lastVerdict ?? false;
     }
@@ -262,6 +267,37 @@ describe("VOD layout convergence", () => {
 
     const recovered = await until(() => player.canvas.style.height === "100%");
     expect(recovered).toBe(true);
+  });
+
+  it("re-measures immediately when a deferral finds no transition to wait for", async () => {
+    // Contract completeness: if the settle hook reports nothing to
+    // wait for (transitions vanished between reads - only reachable
+    // with instrumentation for native transitions), the caller must
+    // measure again right away instead of keeping the stale verdict.
+    // The deferral is injected on the LAST resize event, so nothing
+    // later would rescue a stale verdict.
+    let deferNext = false;
+    player = buildPlayer({
+      parentCss: "display:block;width:800px",
+      width: "100%",
+      height: "100%",
+      probeFn: (container, output) => {
+        if (deferNext) {
+          deferNext = false;
+          return null;
+        }
+        return containerHeightIndependent(container, output);
+      },
+    });
+    expect(await settles(player.stats)).toBe(true);
+    expect(player.canvas.style.height).toBe("auto"); // content-sized verdict
+
+    deferNext = true;
+    player.parent.style.height = "300px"; // correct verdict flips
+
+    const recovered = await until(() => player.canvas.style.height === "100%");
+    expect(recovered).toBe(true);
+    expect(deferNext).toBe(false);
   });
 
   it("self-check: a wrong independent verdict makes the harness detect oscillation", async () => {

--- a/tests/browser/ui-integration.test.js
+++ b/tests/browser/ui-integration.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { UI } from "@/ui/ui";
+import { MODE } from "@/shared/values";
+
+// Integration tests for the production probe wiring in
+// UI._resizeAndRedraw - unlike the convergence harness these construct
+// the real UI class, so the deferred-retry path is exercised together
+// with destroy() and replaceMediaElement().
+
+const stubBus = { on() {}, off() {}, emit() {} };
+
+function waitFrames(n = 2) {
+  return new Promise((resolve) => {
+    const step = (left) =>
+      left ? requestAnimationFrame(() => step(left - 1)) : resolve();
+    step(n);
+  });
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function until(fn, timeout = 3000) {
+  const start = performance.now();
+  while (performance.now() - start < timeout) {
+    if (fn()) return true;
+    await wait(50);
+  }
+  return !!fn();
+}
+
+describe("UI probe integration", () => {
+  let parent;
+  let ui;
+
+  afterEach(() => {
+    try {
+      ui?.destroy();
+    } catch {
+      // already destroyed by the test
+    }
+    ui = undefined;
+    parent?.remove();
+    parent = undefined;
+  });
+
+  async function buildVodPlayer() {
+    parent = document.createElement("div");
+    parent.style.cssText = "display:block;width:800px";
+    document.body.appendChild(parent);
+    ui = new UI(
+      "probe-it",
+      parent,
+      { width: "100%", height: "100%", vod: {}, ar: "16:9" },
+      stubBus,
+    );
+    ui._mode = MODE.VOD;
+    ui._mediaElement.style.display = "block";
+    await waitFrames(3); // initial ResizeObserver delivery + rAF chain
+    return ui;
+  }
+
+  async function deferProbeWithFade() {
+    const media = ui._mediaElement;
+    media.style.transition = "opacity 0.25s linear";
+    void media.offsetHeight;
+    media.style.opacity = "0.5";
+    await waitFrames(2);
+    expect(media.getAnimations().length).toBeGreaterThan(0);
+    // A resize while the fade runs defers the probe and arms the retry.
+    parent.style.height = "300px";
+    await until(() => ui._probeRetryPending === true);
+    expect(ui._probeRetryPending).toBe(true);
+  }
+
+  it("applies the probed layout through the real resize path", async () => {
+    await buildVodPlayer();
+
+    await until(() => ui._mediaElement.style.height === "auto");
+    // Heightless parent: content-sized verdict, width-constrained.
+    expect(ui._mediaElement.style.width).toBe("100%");
+    expect(ui._mediaElement.style.height).toBe("auto");
+  });
+
+  it("recovers the verdict after a deferred retry (production wiring)", async () => {
+    await buildVodPlayer();
+    await deferProbeWithFade();
+
+    // Once the fade settles, the retry re-measures: the parent is now
+    // definite, so the rect fit (height-constrained) must come back.
+    const recovered = await until(
+      () => ui._mediaElement.style.height === "100%",
+    );
+    expect(recovered).toBe(true);
+    expect(ui._probeRetryPending).toBe(false);
+  });
+
+  it("survives destroy() while a deferred retry is pending", async () => {
+    await buildVodPlayer();
+    await deferProbeWithFade();
+
+    ui.destroy();
+
+    // The retry fires after the fade ends; the isConnected guard must
+    // swallow it without touching the destroyed player (an unhandled
+    // error here fails the test).
+    await wait(500);
+    expect(ui._container.isConnected).toBe(false);
+  });
+
+  it("survives replaceMediaElement() while a deferred retry is pending", async () => {
+    await buildVodPlayer();
+    await deferProbeWithFade();
+    const oldMedia = ui._mediaElement;
+
+    await ui.replaceMediaElement();
+    expect(ui._mediaElement).not.toBe(oldMedia);
+
+    // The settle hook watches the OLD element's transitions; when they
+    // finish, the retry re-derives the current output and applies the
+    // definite-parent verdict to the replacement.
+    const recovered = await until(
+      () => ui._mediaElement.style.height === "100%",
+    );
+    expect(recovered).toBe(true);
+  });
+});

--- a/tests/browser/ui-integration.test.js
+++ b/tests/browser/ui-integration.test.js
@@ -9,6 +9,11 @@ import { MODE } from "@/shared/values";
 
 const stubBus = { on() {}, off() {}, emit() {} };
 
+// Long enough that the fade is still live when the resize event
+// reaches the probe on a slow CI runner (ResizeObserver delivery plus
+// two rAF hops can stretch past half a second under contention).
+const FADE_MS = 1500;
+
 function waitFrames(n = 2) {
   return new Promise((resolve) => {
     const step = (left) =>
@@ -45,14 +50,14 @@ describe("UI probe integration", () => {
     parent = undefined;
   });
 
-  async function buildVodPlayer() {
+  async function buildVodPlayer(optOverrides = {}) {
     parent = document.createElement("div");
     parent.style.cssText = "display:block;width:800px";
     document.body.appendChild(parent);
     ui = new UI(
       "probe-it",
       parent,
-      { width: "100%", height: "100%", vod: {}, ar: "16:9" },
+      { width: "100%", height: "100%", vod: {}, ar: "16:9", ...optOverrides },
       stubBus,
     );
     ui._mode = MODE.VOD;
@@ -63,7 +68,7 @@ describe("UI probe integration", () => {
 
   async function deferProbeWithFade() {
     const media = ui._mediaElement;
-    media.style.transition = "opacity 0.25s linear";
+    media.style.transition = `opacity ${FADE_MS}ms linear`;
     void media.offsetHeight;
     media.style.opacity = "0.5";
     await waitFrames(2);
@@ -72,6 +77,20 @@ describe("UI probe integration", () => {
     parent.style.height = "300px";
     await until(() => ui._probeRetryPending === true);
     expect(ui._probeRetryPending).toBe(true);
+  }
+
+  // Counts probe entries by instrumenting the getAnimations call the
+  // probe makes first; production behavior is otherwise untouched.
+  function countProbeTouches(...elements) {
+    const counter = { count: 0 };
+    for (const el of elements) {
+      const original = el.getAnimations.bind(el);
+      el.getAnimations = () => {
+        counter.count++;
+        return original();
+      };
+    }
+    return counter;
   }
 
   it("applies the probed layout through the real resize path", async () => {
@@ -91,6 +110,7 @@ describe("UI probe integration", () => {
     // definite, so the rect fit (height-constrained) must come back.
     const recovered = await until(
       () => ui._mediaElement.style.height === "100%",
+      FADE_MS + 2500,
     );
     expect(recovered).toBe(true);
     expect(ui._probeRetryPending).toBe(false);
@@ -105,8 +125,62 @@ describe("UI probe integration", () => {
     // The retry fires after the fade ends; the isConnected guard must
     // swallow it without touching the destroyed player (an unhandled
     // error here fails the test).
-    await wait(500);
+    await wait(FADE_MS + 500);
     expect(ui._container.isConnected).toBe(false);
+  });
+
+  it("keeps the original auto-height scenario stable end to end", async () => {
+    // The literal PR #86 configuration on the production UI class:
+    // height auto never probes, and the layout must hold a fixed point.
+    await buildVodPlayer({ height: "auto" });
+
+    await until(
+      () =>
+        ui._mediaElement.style.height === "auto" &&
+        ui._mediaElement.style.width === "100%",
+    );
+    const settledHeight = ui._container.getBoundingClientRect().height;
+    await wait(400);
+    expect(ui._container.getBoundingClientRect().height).toBe(settledHeight);
+    expect(ui._mediaElement.style.height).toBe("auto");
+    expect(ui._mediaElement.style.width).toBe("100%");
+  });
+
+  it("skips the probe in PiP mode and in LIVE canvas mode", async () => {
+    // Regression pin for the !isFullscreen && !canvasOutput guard: a
+    // viewport-sized PiP container and the LIVE canvas branch must
+    // never pay for (or be perturbed by) the probe.
+    await buildVodPlayer();
+    const touches = countProbeTouches(ui._mediaElement, ui._canvas);
+
+    ui._mode = MODE.LIVE;
+    ui._resizeAndRedraw({ width: 800, height: 450 }, false);
+
+    ui._mode = MODE.VOD;
+    ui._pipContainer = document.createElement("div");
+    document.body.appendChild(ui._pipContainer);
+    ui._resizeAndRedraw({ width: 800, height: 450 }, true);
+    ui._pipContainer.remove();
+    ui._pipContainer = undefined;
+
+    expect(touches.count).toBe(0);
+
+    // Sanity: the plain VOD path does probe, so the counter has teeth.
+    ui._resizeAndRedraw({ width: 800, height: 450 }, false);
+    expect(touches.count).toBeGreaterThan(0);
+  });
+
+  it("skips the probe while the layout manager is paused", async () => {
+    // fullLayout() bails when paused; the probe's forced layouts must
+    // not run for nothing on every resize event.
+    await buildVodPlayer();
+    const touches = countProbeTouches(ui._mediaElement);
+
+    ui._layoutMgr.pause();
+    ui._resizeAndRedraw({ width: 800, height: 450 }, false);
+    ui._layoutMgr.resume();
+
+    expect(touches.count).toBe(0);
   });
 
   it("survives replaceMediaElement() while a deferred retry is pending", async () => {
@@ -122,6 +196,7 @@ describe("UI probe integration", () => {
     // definite-parent verdict to the replacement.
     const recovered = await until(
       () => ui._mediaElement.style.height === "100%",
+      FADE_MS + 2500,
     );
     expect(recovered).toBe(true);
   });

--- a/tests/layout-manager.test.js
+++ b/tests/layout-manager.test.js
@@ -602,17 +602,28 @@ describe("UILayoutManager", () => {
     });
 
     it("is false for definite heights", () => {
-      for (const height of [480, "50vh", "480px", ".5em", "1.5rem"]) {
+      for (const height of [
+        480,
+        "50vh",
+        "480px",
+        ".5em",
+        "1.5rem",
+        "+1px",
+        "1e2px",
+        "1E-2em",
+        "+.5rem",
+      ]) {
         expect(
           new UILayoutManager("100%", height, "16:9").heightNeedsProbe(),
         ).toBe(false);
       }
     });
 
-    it("is true for malformed numeric lengths", () => {
-      // Browsers reject these declarations, leaving the height
-      // effectively auto - they must be measured, not trusted.
-      for (const height of ["1.2.3px", ".px", "....vh", "1..5em"]) {
+    it("is true for malformed or negative numeric lengths", () => {
+      // Browsers reject these declarations (negative heights are
+      // invalid), leaving the height effectively auto - they must be
+      // measured, not trusted.
+      for (const height of ["1.2.3px", ".px", "....vh", "1..5em", "-1px"]) {
         expect(
           new UILayoutManager("100%", height, "16:9").heightNeedsProbe(),
         ).toBe(true);

--- a/tests/layout-manager.test.js
+++ b/tests/layout-manager.test.js
@@ -614,6 +614,33 @@ describe("UILayoutManager", () => {
     });
   });
 
+  describe("canLayout", () => {
+    // ui.js consults this before running the DOM probe: when fullLayout
+    // would bail anyway (no aspect ratio yet, or paused), the probe's
+    // forced layouts are wasted work.
+
+    it("is false without an aspect ratio", () => {
+      expect(new UILayoutManager(640, 480).canLayout()).toBe(false);
+    });
+
+    it("is false while paused", () => {
+      const ui = new UILayoutManager(640, 480, "16:9");
+      ui.pause();
+
+      expect(ui.canLayout()).toBe(false);
+    });
+
+    it("is true with an aspect ratio while not paused", () => {
+      const ui = new UILayoutManager(640, 480, "16:9");
+
+      expect(ui.canLayout()).toBe(true);
+
+      ui.pause();
+      ui.resume();
+      expect(ui.canLayout()).toBe(true);
+    });
+  });
+
   describe("heightNeedsProbe", () => {
     // ui.js runs a DOM probe (does the container height follow the
     // output?) only for context-dependent heights - %, var(), inherit -

--- a/tests/layout-manager.test.js
+++ b/tests/layout-manager.test.js
@@ -306,6 +306,149 @@ describe("UILayoutManager", () => {
       });
     });
 
+    describe("VOD mode with an indefinite container height", () => {
+      // The flicker guard must key on definiteness, not on the literal
+      // "auto": a percentage height inside a parent with no definite
+      // height behaves as auto, so the rect-based fit feeds back and
+      // oscillates the same way. Definiteness of a percentage is decided
+      // by the caller (a DOM probe in ui.js) and passed in as the
+      // parentHeightDefinite flag - the last fullLayout argument below.
+
+      it("uses width as the constraint for a percentage height when the parent height is indefinite", () => {
+        const ui = new UILayoutManager("100%", "100%", "16:9");
+
+        const wide = ui.fullLayout(1000, 563, MODE.VOD, false, false, false);
+        expect(wide.output.width).toBe("100%");
+        expect(wide.output.height).toBe("auto");
+
+        // The intrinsic-size rect those styles produce must map back to
+        // the very same styles - a single fixed point, no oscillation.
+        const tall = ui.fullLayout(1000, 720, MODE.VOD, false, false, false);
+        expect(tall.output.width).toBe("100%");
+        expect(tall.output.height).toBe("auto");
+      });
+
+      it("keeps the rect-based fit for a percentage height when the parent height is definite", () => {
+        // Here the rect is trustworthy and dropping the fit would lose
+        // letterboxing (and overflow a shorter-than-aspect box).
+        const ui = new UILayoutManager("100%", "100%", "16:9");
+
+        const wide = ui.fullLayout(2000, 1000, MODE.VOD, false, false, true);
+        expect(wide.output.width).toBe("auto");
+        expect(wide.output.height).toBe("100%");
+
+        const narrow = ui.fullLayout(500, 400, MODE.VOD, false, false, true);
+        expect(narrow.output.width).toBe("100%");
+        expect(narrow.output.height).toBe("auto");
+      });
+
+      it("treats content-based height keywords as indefinite regardless of the flag", () => {
+        for (const height of ["fit-content", "min-content", "max-content"]) {
+          const ui = new UILayoutManager("100%", height, "16:9");
+
+          const result = ui.fullLayout(1000, 563, MODE.VOD, false, false, true);
+          expect(result.output.width).toBe("100%");
+          expect(result.output.height).toBe("auto");
+        }
+      });
+
+      it("classifies functions containing a percentage by the parent's definiteness", () => {
+        for (const height of ["calc(100% - 40px)", "min(100%, 480px)"]) {
+          const ui = new UILayoutManager("100%", height, "16:9");
+
+          const indefinite = ui.fullLayout(
+            1000,
+            563,
+            MODE.VOD,
+            false,
+            false,
+            false,
+          );
+          expect(indefinite.output.width).toBe("100%");
+          expect(indefinite.output.height).toBe("auto");
+
+          const definite = ui.fullLayout(
+            2000,
+            1000,
+            MODE.VOD,
+            false,
+            false,
+            true,
+          );
+          expect(definite.output.width).toBe("auto");
+          expect(definite.output.height).toBe("100%");
+        }
+      });
+
+      it("keeps the rect-based fit for absolute heights regardless of the flag", () => {
+        for (const height of ["480px", "50vh", "20em"]) {
+          const ui = new UILayoutManager("100%", height, "16:9");
+
+          const result = ui.fullLayout(
+            2000,
+            1000,
+            MODE.VOD,
+            false,
+            false,
+            false,
+          );
+          expect(result.output.width).toBe("auto");
+          expect(result.output.height).toBe("100%");
+        }
+      });
+
+      it("keeps the rect-based fit in fullscreen where the container is viewport-sized", () => {
+        const ui = new UILayoutManager("100%", "100%", "16:9");
+
+        const result = ui.fullLayout(2000, 1000, MODE.VOD, true, false, false);
+        expect(result.output.width).toBe("auto");
+        expect(result.output.height).toBe("100%");
+      });
+
+      it("combines an auto width with an indefinite percentage height", () => {
+        const ui = new UILayoutManager("auto", "100%", "16:9");
+
+        const result = ui.fullLayout(1000, 563, MODE.VOD, false, false, false);
+        expect(result.output.width).toBe("auto");
+        expect(result.output.height).toBe("auto");
+      });
+
+      it("applies the same constraint in media-element mode", () => {
+        const ui = new UILayoutManager("100%", "100%", "16:9");
+
+        const result = ui.fullLayout(1000, 563, MODE.LIVE, false, true, false);
+        expect(result.output.width).toBe("100%");
+        expect(result.output.height).toBe("auto");
+      });
+
+      it("uses pixel sizes in media-element mode when the parent height is definite", () => {
+        const ui = new UILayoutManager("100%", "100%", "16:9");
+
+        const result = ui.fullLayout(2000, 1000, MODE.LIVE, false, true, true);
+        expect(result.output.width).toBe("2000px");
+        expect(result.output.height).toBe("100%");
+      });
+
+      it("uses the rect-based fit for frame-sized players once the frame size is known", () => {
+        // Empty width/height settings resolve to pixel dimensions on the
+        // first frame - definite from then on, whatever the flag says.
+        const ui = new UILayoutManager(undefined, undefined, "16:9");
+        ui.setFrameSize(1920, 1080);
+
+        const result = ui.fullLayout(2000, 1000, MODE.VOD, false, false, false);
+        expect(result.output.width).toBe("auto");
+        expect(result.output.height).toBe("100%");
+      });
+
+      it("sizes intrinsically for frame-sized players before the first frame", () => {
+        const ui = new UILayoutManager(undefined, undefined, "16:9");
+
+        const result = ui.fullLayout(1000, 563, MODE.VOD, false, false, false);
+        expect(result.output.width).toBe("auto");
+        expect(result.output.height).toBe("auto");
+      });
+    });
+
     it("returns container dimensions in fullscreen mode", () => {
       const ui = new UILayoutManager(640, 480, "16:9");
 
@@ -326,6 +469,67 @@ describe("UILayoutManager", () => {
         "object-fit": "fill",
         "aspect-ratio": "16 / 9",
       });
+    });
+  });
+
+  describe("heightNeedsParentProbe", () => {
+    // ui.js runs a DOM probe against the container's parent only when
+    // the configured height is percentage-based - the sole case whose
+    // definiteness the layout manager can't classify on its own.
+
+    it("is false for intrinsic heights", () => {
+      expect(
+        new UILayoutManager("100%", "auto", "16:9").heightNeedsParentProbe(),
+      ).toBe(false);
+      expect(
+        new UILayoutManager(
+          "100%",
+          "fit-content",
+          "16:9",
+        ).heightNeedsParentProbe(),
+      ).toBe(false);
+      expect(
+        new UILayoutManager("100%", undefined, "16:9").heightNeedsParentProbe(),
+      ).toBe(false);
+    });
+
+    it("is false for definite heights", () => {
+      expect(
+        new UILayoutManager("100%", 480, "16:9").heightNeedsParentProbe(),
+      ).toBe(false);
+      expect(
+        new UILayoutManager("100%", "50vh", "16:9").heightNeedsParentProbe(),
+      ).toBe(false);
+    });
+
+    it("is true for percentage heights", () => {
+      expect(
+        new UILayoutManager("100%", "100%", "16:9").heightNeedsParentProbe(),
+      ).toBe(true);
+    });
+
+    it("is true for functions containing a percentage", () => {
+      expect(
+        new UILayoutManager(
+          "100%",
+          "calc(100% - 40px)",
+          "16:9",
+        ).heightNeedsParentProbe(),
+      ).toBe(true);
+      expect(
+        new UILayoutManager(
+          "100%",
+          "min(100%, 480px)",
+          "16:9",
+        ).heightNeedsParentProbe(),
+      ).toBe(true);
+    });
+
+    it("is false once frame sizing resolves empty dimensions to pixels", () => {
+      const ui = new UILayoutManager();
+      ui.setFrameSize(1920, 1080);
+
+      expect(ui.heightNeedsParentProbe()).toBe(false);
     });
   });
 

--- a/tests/layout-manager.test.js
+++ b/tests/layout-manager.test.js
@@ -440,6 +440,86 @@ describe("UILayoutManager", () => {
         expect(result.output.height).toBe("100%");
       });
 
+      it("treats css-wide keywords and keyword case variants as indefinite", () => {
+        for (const height of ["AUTO", " auto ", "initial", "unset", "revert"]) {
+          const ui = new UILayoutManager("100%", height, "16:9");
+
+          // These compute to auto, so the flag must not matter.
+          const result = ui.fullLayout(
+            2000,
+            1000,
+            MODE.VOD,
+            false,
+            false,
+            true,
+          );
+          expect(result.output.width).toBe("100%");
+          expect(result.output.height).toBe("auto");
+        }
+      });
+
+      it("resolves inherit through the parent flag", () => {
+        const ui = new UILayoutManager("100%", "inherit", "16:9");
+
+        const indefinite = ui.fullLayout(
+          1000,
+          563,
+          MODE.VOD,
+          false,
+          false,
+          false,
+        );
+        expect(indefinite.output.width).toBe("100%");
+        expect(indefinite.output.height).toBe("auto");
+
+        const definite = ui.fullLayout(
+          2000,
+          1000,
+          MODE.VOD,
+          false,
+          false,
+          true,
+        );
+        expect(definite.output.width).toBe("auto");
+        expect(definite.output.height).toBe("100%");
+      });
+
+      it("resolves var() heights through the parent flag", () => {
+        const ui = new UILayoutManager("100%", "var(--player-height)", "16:9");
+
+        const indefinite = ui.fullLayout(
+          1000,
+          563,
+          MODE.VOD,
+          false,
+          false,
+          false,
+        );
+        expect(indefinite.output.width).toBe("100%");
+        expect(indefinite.output.height).toBe("auto");
+
+        const definite = ui.fullLayout(
+          2000,
+          1000,
+          MODE.VOD,
+          false,
+          false,
+          true,
+        );
+        expect(definite.output.width).toBe("auto");
+        expect(definite.output.height).toBe("100%");
+      });
+
+      it("keeps an intrinsic width for content-based width keywords", () => {
+        // A fit-content width is sized by the output too; forcing
+        // width:100% against it would be cyclic.
+        const ui = new UILayoutManager("fit-content", "auto", "16:9");
+
+        const result = ui.fullLayout(1000, 563, MODE.VOD, false, false, false);
+        expect(result.output.width).toBe("auto");
+        expect(result.output.height).toBe("auto");
+      });
+
       it("sizes intrinsically for frame-sized players before the first frame", () => {
         const ui = new UILayoutManager(undefined, undefined, "16:9");
 
@@ -502,9 +582,40 @@ describe("UILayoutManager", () => {
       ).toBe(false);
     });
 
+    it("is false for css-wide keywords and keyword case variants", () => {
+      for (const height of ["AUTO", " auto ", "initial", "unset", "revert"]) {
+        expect(
+          new UILayoutManager("100%", height, "16:9").heightNeedsParentProbe(),
+        ).toBe(false);
+      }
+    });
+
     it("is true for percentage heights", () => {
       expect(
         new UILayoutManager("100%", "100%", "16:9").heightNeedsParentProbe(),
+      ).toBe(true);
+      expect(
+        new UILayoutManager("100%", " 100% ", "16:9").heightNeedsParentProbe(),
+      ).toBe(true);
+    });
+
+    it("is true for inherit", () => {
+      // inherit copies the parent's computed height, so its definiteness
+      // is exactly what the parent probe measures.
+      expect(
+        new UILayoutManager("100%", "inherit", "16:9").heightNeedsParentProbe(),
+      ).toBe(true);
+    });
+
+    it("is true for var() heights", () => {
+      // A custom property can hide any value; the probe keeps the layout
+      // stable either way, so it decides.
+      expect(
+        new UILayoutManager(
+          "100%",
+          "var(--player-height)",
+          "16:9",
+        ).heightNeedsParentProbe(),
       ).toBe(true);
     });
 

--- a/tests/layout-manager.test.js
+++ b/tests/layout-manager.test.js
@@ -511,6 +511,37 @@ describe("UILayoutManager", () => {
         expect(definite.output.height).toBe("100%");
       });
 
+      it("resolves env() and calc-size() heights through the probe flag", () => {
+        for (const height of [
+          "env(safe-area-inset-bottom, auto)",
+          "calc-size(auto, size)",
+        ]) {
+          const ui = new UILayoutManager("100%", height, "16:9");
+
+          const dependent = ui.fullLayout(
+            1000,
+            563,
+            MODE.VOD,
+            false,
+            false,
+            false,
+          );
+          expect(dependent.output.width).toBe("100%");
+          expect(dependent.output.height).toBe("auto");
+
+          const independent = ui.fullLayout(
+            2000,
+            1000,
+            MODE.VOD,
+            false,
+            false,
+            true,
+          );
+          expect(independent.output.width).toBe("auto");
+          expect(independent.output.height).toBe("100%");
+        }
+      });
+
       it("keeps an intrinsic width for content-based width keywords", () => {
         // A fit-content width is sized by the output too; forcing
         // width:100% against it would be cyclic.
@@ -614,6 +645,23 @@ describe("UILayoutManager", () => {
           "16:9",
         ).heightNeedsProbe(),
       ).toBe(true);
+    });
+
+    it("is true for any syntax that is not a plain absolute length", () => {
+      // Only positively recognized absolute lengths skip the probe -
+      // env() can resolve to its fallback (possibly auto), calc-size()
+      // keeps intrinsic sizing behavior, and future syntax is unknown.
+      for (const height of [
+        "env(safe-area-inset-bottom, auto)",
+        "calc-size(auto, size)",
+        "calc(50vh - 10px)",
+        "min(10vh, 200px)",
+        "foo(12px)",
+      ]) {
+        expect(
+          new UILayoutManager("100%", height, "16:9").heightNeedsProbe(),
+        ).toBe(true);
+      }
     });
 
     it("is true for functions containing a percentage", () => {

--- a/tests/layout-manager.test.js
+++ b/tests/layout-manager.test.js
@@ -310,9 +310,10 @@ describe("UILayoutManager", () => {
       // The flicker guard must key on definiteness, not on the literal
       // "auto": a percentage height inside a parent with no definite
       // height behaves as auto, so the rect-based fit feeds back and
-      // oscillates the same way. Definiteness of a percentage is decided
-      // by the caller (a DOM probe in ui.js) and passed in as the
-      // parentHeightDefinite flag - the last fullLayout argument below.
+      // oscillates the same way. Context-dependent heights (%, var(),
+      // inherit) are resolved by the caller (a DOM probe in ui.js) and
+      // passed in as the heightIndependent flag - the last fullLayout
+      // argument below.
 
       it("uses width as the constraint for a percentage height when the parent height is indefinite", () => {
         const ui = new UILayoutManager("100%", "100%", "16:9");
@@ -552,50 +553,46 @@ describe("UILayoutManager", () => {
     });
   });
 
-  describe("heightNeedsParentProbe", () => {
-    // ui.js runs a DOM probe against the container's parent only when
-    // the configured height is percentage-based - the sole case whose
-    // definiteness the layout manager can't classify on its own.
+  describe("heightNeedsProbe", () => {
+    // ui.js runs a DOM probe (does the container height follow the
+    // output?) only for context-dependent heights - %, var(), inherit -
+    // which the layout manager can't classify on its own.
 
     it("is false for intrinsic heights", () => {
       expect(
-        new UILayoutManager("100%", "auto", "16:9").heightNeedsParentProbe(),
+        new UILayoutManager("100%", "auto", "16:9").heightNeedsProbe(),
       ).toBe(false);
       expect(
-        new UILayoutManager(
-          "100%",
-          "fit-content",
-          "16:9",
-        ).heightNeedsParentProbe(),
+        new UILayoutManager("100%", "fit-content", "16:9").heightNeedsProbe(),
       ).toBe(false);
       expect(
-        new UILayoutManager("100%", undefined, "16:9").heightNeedsParentProbe(),
+        new UILayoutManager("100%", undefined, "16:9").heightNeedsProbe(),
       ).toBe(false);
     });
 
     it("is false for definite heights", () => {
+      expect(new UILayoutManager("100%", 480, "16:9").heightNeedsProbe()).toBe(
+        false,
+      );
       expect(
-        new UILayoutManager("100%", 480, "16:9").heightNeedsParentProbe(),
-      ).toBe(false);
-      expect(
-        new UILayoutManager("100%", "50vh", "16:9").heightNeedsParentProbe(),
+        new UILayoutManager("100%", "50vh", "16:9").heightNeedsProbe(),
       ).toBe(false);
     });
 
     it("is false for css-wide keywords and keyword case variants", () => {
       for (const height of ["AUTO", " auto ", "initial", "unset", "revert"]) {
         expect(
-          new UILayoutManager("100%", height, "16:9").heightNeedsParentProbe(),
+          new UILayoutManager("100%", height, "16:9").heightNeedsProbe(),
         ).toBe(false);
       }
     });
 
     it("is true for percentage heights", () => {
       expect(
-        new UILayoutManager("100%", "100%", "16:9").heightNeedsParentProbe(),
+        new UILayoutManager("100%", "100%", "16:9").heightNeedsProbe(),
       ).toBe(true);
       expect(
-        new UILayoutManager("100%", " 100% ", "16:9").heightNeedsParentProbe(),
+        new UILayoutManager("100%", " 100% ", "16:9").heightNeedsProbe(),
       ).toBe(true);
     });
 
@@ -603,7 +600,7 @@ describe("UILayoutManager", () => {
       // inherit copies the parent's computed height, so its definiteness
       // is exactly what the parent probe measures.
       expect(
-        new UILayoutManager("100%", "inherit", "16:9").heightNeedsParentProbe(),
+        new UILayoutManager("100%", "inherit", "16:9").heightNeedsProbe(),
       ).toBe(true);
     });
 
@@ -615,7 +612,7 @@ describe("UILayoutManager", () => {
           "100%",
           "var(--player-height)",
           "16:9",
-        ).heightNeedsParentProbe(),
+        ).heightNeedsProbe(),
       ).toBe(true);
     });
 
@@ -625,14 +622,14 @@ describe("UILayoutManager", () => {
           "100%",
           "calc(100% - 40px)",
           "16:9",
-        ).heightNeedsParentProbe(),
+        ).heightNeedsProbe(),
       ).toBe(true);
       expect(
         new UILayoutManager(
           "100%",
           "min(100%, 480px)",
           "16:9",
-        ).heightNeedsParentProbe(),
+        ).heightNeedsProbe(),
       ).toBe(true);
     });
 
@@ -640,7 +637,7 @@ describe("UILayoutManager", () => {
       const ui = new UILayoutManager();
       ui.setFrameSize(1920, 1080);
 
-      expect(ui.heightNeedsParentProbe()).toBe(false);
+      expect(ui.heightNeedsProbe()).toBe(false);
     });
   });
 

--- a/tests/layout-manager.test.js
+++ b/tests/layout-manager.test.js
@@ -441,8 +441,38 @@ describe("UILayoutManager", () => {
         expect(result.output.height).toBe("100%");
       });
 
+      it("resolves revert and revert-layer through the probe flag", () => {
+        // revert-layer from inline style can land on a definite
+        // stylesheet height, so the measured verdict decides.
+        for (const height of ["revert", "revert-layer"]) {
+          const ui = new UILayoutManager("100%", height, "16:9");
+
+          const dependent = ui.fullLayout(
+            1000,
+            563,
+            MODE.VOD,
+            false,
+            false,
+            false,
+          );
+          expect(dependent.output.width).toBe("100%");
+          expect(dependent.output.height).toBe("auto");
+
+          const independent = ui.fullLayout(
+            2000,
+            1000,
+            MODE.VOD,
+            false,
+            false,
+            true,
+          );
+          expect(independent.output.width).toBe("auto");
+          expect(independent.output.height).toBe("100%");
+        }
+      });
+
       it("treats css-wide keywords and keyword case variants as indefinite", () => {
-        for (const height of ["AUTO", " auto ", "initial", "unset", "revert"]) {
+        for (const height of ["AUTO", " auto ", "initial", "unset"]) {
           const ui = new UILayoutManager("100%", height, "16:9");
 
           // These compute to auto, so the flag must not matter.
@@ -639,10 +669,21 @@ describe("UILayoutManager", () => {
     });
 
     it("is false for css-wide keywords and keyword case variants", () => {
-      for (const height of ["AUTO", " auto ", "initial", "unset", "revert"]) {
+      for (const height of ["AUTO", " auto ", "initial", "unset"]) {
         expect(
           new UILayoutManager("100%", height, "16:9").heightNeedsProbe(),
         ).toBe(false);
+      }
+    });
+
+    it("is true for revert and revert-layer", () => {
+      // revert-layer from the style attribute falls back into author
+      // stylesheet rules, which may define a definite height; revert
+      // can expose user-origin styles. Both must be measured.
+      for (const height of ["revert", "revert-layer"]) {
+        expect(
+          new UILayoutManager("100%", height, "16:9").heightNeedsProbe(),
+        ).toBe(true);
       }
     });
 

--- a/tests/layout-manager.test.js
+++ b/tests/layout-manager.test.js
@@ -602,12 +602,21 @@ describe("UILayoutManager", () => {
     });
 
     it("is false for definite heights", () => {
-      expect(new UILayoutManager("100%", 480, "16:9").heightNeedsProbe()).toBe(
-        false,
-      );
-      expect(
-        new UILayoutManager("100%", "50vh", "16:9").heightNeedsProbe(),
-      ).toBe(false);
+      for (const height of [480, "50vh", "480px", ".5em", "1.5rem"]) {
+        expect(
+          new UILayoutManager("100%", height, "16:9").heightNeedsProbe(),
+        ).toBe(false);
+      }
+    });
+
+    it("is true for malformed numeric lengths", () => {
+      // Browsers reject these declarations, leaving the height
+      // effectively auto - they must be measured, not trusted.
+      for (const height of ["1.2.3px", ".px", "....vh", "1..5em"]) {
+        expect(
+          new UILayoutManager("100%", height, "16:9").heightNeedsProbe(),
+        ).toBe(true);
+      }
     });
 
     it("is false for css-wide keywords and keyword case variants", () => {

--- a/tests/layout-manager.test.js
+++ b/tests/layout-manager.test.js
@@ -245,6 +245,67 @@ describe("UILayoutManager", () => {
       });
     });
 
+    describe("VOD mode with an auto container dimension", () => {
+      // An auto container HEIGHT derives from the output element itself
+      // (the container is a block element), so sizing the output from the
+      // measured rect feeds back into the container size: the branch
+      // comparison flips between measurements and the layout oscillates
+      // (visible flicker). An auto WIDTH resolves to the parent's width -
+      // definite and feedback-free - so the rect stays trustworthy there.
+
+      it("keeps width as the constraint when the height is auto", () => {
+        const ui = new UILayoutManager("100%", "auto", "16:9");
+
+        // A rect matching the aspect ratio used to flip to height-fit.
+        const wide = ui.fullLayout(1000, 563, MODE.VOD, false);
+        expect(wide.output.width).toBe("100%");
+        expect(wide.output.height).toBe("auto");
+
+        // The intrinsic-size rect the flip produces must map to the very
+        // same styles - a single fixed point instead of an oscillation.
+        const tall = ui.fullLayout(1000, 720, MODE.VOD, false);
+        expect(tall.output.width).toBe("100%");
+        expect(tall.output.height).toBe("auto");
+      });
+
+      it("keeps the rect-based fit when only the width is auto", () => {
+        // Width auto is parent-derived on a block container: the measured
+        // rect is stable, and forcing height-fit here would overflow a
+        // parent narrower than the aspect-sized video.
+        const ui = new UILayoutManager("auto", 400, "16:9");
+
+        const wide = ui.fullLayout(1000, 400, MODE.VOD, false);
+        expect(wide.output.width).toBe("auto");
+        expect(wide.output.height).toBe("100%");
+
+        // A narrow parent letterboxes inside the fixed-height container.
+        const tall = ui.fullLayout(500, 400, MODE.VOD, false);
+        expect(tall.output.width).toBe("100%");
+        expect(tall.output.height).toBe("auto");
+      });
+
+      it("sizes intrinsically when both dimensions are auto", () => {
+        const ui = new UILayoutManager("auto", "auto", "16:9");
+
+        // Rect-independent: the same styles for any measured rect.
+        const wide = ui.fullLayout(1000, 563, MODE.VOD, false);
+        expect(wide.output.width).toBe("auto");
+        expect(wide.output.height).toBe("auto");
+
+        const tall = ui.fullLayout(500, 720, MODE.VOD, false);
+        expect(tall.output.width).toBe("auto");
+        expect(tall.output.height).toBe("auto");
+      });
+
+      it("applies the same constraint in media-element mode", () => {
+        const ui = new UILayoutManager("100%", "auto", "16:9");
+
+        const wide = ui.fullLayout(1000, 563, MODE.LIVE, false, true);
+        expect(wide.output.width).toBe("100%");
+        expect(wide.output.height).toBe("auto");
+      });
+    });
+
     it("returns container dimensions in fullscreen mode", () => {
       const ui = new UILayoutManager(640, 480, "16:9");
 

--- a/tests/layout-manager.test.js
+++ b/tests/layout-manager.test.js
@@ -612,6 +612,14 @@ describe("UILayoutManager", () => {
         "1e2px",
         "1E-2em",
         "+.5rem",
+        "0",
+        "10svi",
+        "5dvb",
+        "3svmin",
+        "4lvmax",
+        "2rex",
+        "1.5rch",
+        "2ric",
       ]) {
         expect(
           new UILayoutManager("100%", height, "16:9").heightNeedsProbe(),

--- a/vitest.browser.config.js
+++ b/vitest.browser.config.js
@@ -1,0 +1,20 @@
+import { mergeConfig } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
+import viteConfig from "./vite.config";
+
+// Real-browser tests for behavior jsdom cannot exercise: CSS layout
+// (height definiteness probing) and ResizeObserver feedback loops.
+export default mergeConfig(viteConfig, {
+  test: {
+    include: ["tests/browser/**/*.test.js"],
+    silent: "passed-only",
+    globals: true,
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright(),
+      instances: [{ browser: "chromium" }],
+      screenshotFailures: false,
+    },
+  },
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,6 +4,8 @@ import viteConfig from "./vite.config";
 export default mergeConfig(viteConfig, {
   test: {
     include: ["tests/**/*.test.js"],
+    // Real-browser tests run separately via vitest.browser.config.js.
+    exclude: ["tests/browser/**"],
     silent: "passed-only",
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
Bug: With width: "100%" and height: "auto", the player flickered in VOD mode, endlessly resizing.
  
Root cause: UILayoutManager.fullLayout() sized the video element from the container rect measured by a ResizeObserver. With height: auto, the container's height derives from the video itself, so the measurement fed back: the aspect comparison alternated between {height: 100%, width: auto} and {width: 100%, height: auto} — and since height: 100% against an auto-height parent resolves to intrinsic sizing, each choice changed the container height and flipped the comparison on the next observer tick. A two-state oscillation, visible as flicker.

Fix: When the container height is auto, skip the rect-based fit and use rect-independent styles — width: 100% (or auto if width is auto too), height: auto, with aspect-ratio keeping the shape — giving the layout a single fixed point. The rect-based fit is kept when only the width is auto: on a block container that resolves to the parent's width, which is definite and feedback-free, preserving letterboxing for fixed-height configs. All other paths (definite sizes, fullscreen, PiP, frame-sized) are unchanged.

Tests: pin the fixed-point property (the oscillation's own output rect must map back to identical styles), the preserved rect fit for width-auto-only including the narrow-parent letterboxing case, intrinsic sizing for both-auto, and the media-element mode variant.